### PR TITLE
Integrate frontend with backend API services

### DIFF
--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -7,7 +7,7 @@ interface LoginFormProps {
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -18,7 +18,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
     setIsLoading(true);
 
     try {
-      await authStore.login(username, password);
+      await authStore.login(email, password);
       onLogin();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Giriş yapılamadı');
@@ -50,14 +50,14 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
             )}
 
             <div>
-              <label htmlFor="username" className="block text-sm font-medium text-gray-700">
-                Kullanıcı Adı
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                E-posta
               </label>
               <input
-                id="username"
-                type="text"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
                 className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                 required
               />
@@ -100,5 +100,4 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
         </div>
       </div>
     </div>
-  );
-};
+  );};

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { 
   FileText, 
   Tags, 
@@ -12,11 +12,16 @@ import {
 import { DashboardCard } from './DashboardCard';
 import { SystemStatus } from './SystemStatus';
 import { DataChart } from './DataChart';
-import { dataStore } from '../../store/dataStore';
+import { dashboardService } from '../../services';
 
 export const Dashboard: React.FC = () => {
-  const stats = dataStore.getDashboardStats();
-  const systemMetrics = dataStore.getSystemMetrics();
+  const [stats, setStats] = useState(dashboardService.stats as any);
+  const [systemMetrics, setSystemMetrics] = useState([] as any[]);
+
+  useEffect(() => {
+    dashboardService.stats().then(setStats);
+    dashboardService.metrics().then(setSystemMetrics);
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -84,5 +89,4 @@ export const Dashboard: React.FC = () => {
         />
       </div>
     </div>
-  );
-};
+  );};

--- a/src/components/Tags/TagList.tsx
+++ b/src/components/Tags/TagList.tsx
@@ -1,14 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Plus, Search, Filter } from 'lucide-react';
 import { ReportTemplateTag } from '../../types';
-import { dataStore } from '../../store/dataStore';
+import { tagService, templateService } from '../../services';
 
 export const TagList: React.FC = () => {
-  const [tags, setTags] = useState<ReportTemplateTag[]>(dataStore.getTags());
+  const [tags, setTags] = useState<ReportTemplateTag[]>([]);
+  const [templates, setTemplates] = useState<{ id: number; name: string }[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTemplate, setSelectedTemplate] = useState<string>('all');
 
-  const templates = dataStore.getTemplates();
+  useEffect(() => {
+    tagService
+      .list({ pageNumber: 0, pageSize: 100 })
+      .then((res) => setTags(res.items));
+    templateService
+      .list({ pageNumber: 0, pageSize: 50 })
+      .then((res) => setTemplates(res.items));
+  }, []);
 
   const filteredTags = tags.filter(tag => {
     const matchesSearch = tag.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -17,8 +25,8 @@ export const TagList: React.FC = () => {
     return matchesSearch && matchesTemplate;
   });
 
-  const getTemplateName = (templateId: string) => {
-    const template = templates.find(t => t.id === templateId);
+  const getTemplateName = (templateId: string | number) => {
+    const template = templates.find(t => t.id === Number(templateId));
     return template?.name || 'Bilinmiyor';
   };
 
@@ -143,5 +151,4 @@ export const TagList: React.FC = () => {
         </div>
       )}
     </div>
-  );
-};
+  );};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,25 @@
+const API_URL = import.meta.env.VITE_API_URL || '';
+
+async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(API_URL + url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+    ...options,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText);
+  }
+  return (await response.json()) as T;
+}
+
+export const api = {
+  get: <T>(url: string) => request<T>(url),
+  post: <T>(url: string, body?: any) =>
+    request<T>(url, { method: 'POST', body: JSON.stringify(body) }),
+  put: <T>(url: string, body?: any) =>
+    request<T>(url, { method: 'PUT', body: JSON.stringify(body) }),
+  delete: <T>(url: string) => request<T>(url, { method: 'DELETE' }),
+};

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,29 @@
+import { api } from './api';
+
+export interface LoginDto {
+  email: string;
+  password: string;
+}
+
+export interface RegisterDto {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+}
+
+export interface RefreshTokenDto {
+  refreshToken: string;
+}
+
+export interface AccessToken {
+  token: string;
+  refreshToken: string;
+  expiration: string;
+}
+
+export const authService = {
+  login: (data: LoginDto) => api.post<AccessToken>('/api/auth/login', data),
+  register: (data: RegisterDto) => api.post<AccessToken>('/api/auth/register', data),
+  refresh: (data: RefreshTokenDto) => api.post<AccessToken>('/api/auth/refresh-token', data),
+};

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,0 +1,27 @@
+import { api } from './api';
+
+export interface DashboardStats {
+  totalTemplates: number;
+  activeTags: number;
+  dataPoints24h: number;
+  systemHealth: string;
+  activeUsers: number;
+  alerts24h: number;
+  uptime: string;
+}
+
+export interface SystemMetric {
+  id: number;
+  name: string;
+  value: number;
+  unit: string;
+  status: string;
+  lastUpdated: string;
+}
+
+export const dashboardService = {
+  stats: () => api.get<DashboardStats>('/api/dashboard'),
+  metrics: () => api.get<SystemMetric[]>('/api/dashboard/metrics'),
+};
+
+

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,6 @@
+export * from './api';
+export * from './authService';
+export * from './templateService';
+export * from './tagService';
+export * from './userService';
+export * from './dashboardService';

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -1,0 +1,20 @@
+import { api } from './api';
+import { PageRequest, PaginatedResponse } from './templateService';
+
+export interface ReportTemplateTagDto {
+  id: number;
+  reportTemplateId: number;
+  tagName: string;
+  tagNodeId: string;
+}
+
+export const tagService = {
+  getById: (id: number) => api.get<ReportTemplateTagDto>(`/api/reporttemplatetags/${id}`),
+  create: (data: Omit<ReportTemplateTagDto, 'id'>) =>
+    api.post<ReportTemplateTagDto>('/api/reporttemplatetags', data),
+  update: (data: ReportTemplateTagDto) =>
+    api.put<ReportTemplateTagDto>('/api/reporttemplatetags', data),
+  delete: (id: number) => api.delete<unknown>(`/api/reporttemplatetags/${id}`),
+  list: (page: PageRequest) =>
+    api.post<PaginatedResponse<ReportTemplateTagDto>>('/api/reporttemplatetags/list?pageIndex=' + page.pageNumber + '&pageSize=' + page.pageSize, {}),
+};

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -1,0 +1,32 @@
+import { api } from './api';
+
+export interface ReportTemplateDto {
+  id: number;
+  name: string;
+  opcEndpoint: string;
+  pullInterval: number;
+  isActive?: boolean;
+}
+
+export interface PageRequest {
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  pageIndex: number;
+  pageSize: number;
+  count: number;
+}
+
+export const templateService = {
+  getById: (id: number) => api.get<ReportTemplateDto>(`/api/reporttemplates/${id}`),
+  create: (data: Omit<ReportTemplateDto, 'id'>) =>
+    api.post<ReportTemplateDto>('/api/reporttemplates', data),
+  update: (data: ReportTemplateDto) =>
+    api.put<ReportTemplateDto>('/api/reporttemplates', data),
+  delete: (id: number) => api.delete<unknown>(`/api/reporttemplates/${id}`),
+  list: (page: PageRequest) =>
+    api.post<PaginatedResponse<ReportTemplateDto>>('/api/reporttemplates/list?pageIndex=' + page.pageNumber + '&pageSize=' + page.pageSize, {}),
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,21 @@
+import { api } from './api';
+import { PageRequest, PaginatedResponse } from './templateService';
+
+export interface UserDto {
+  id: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  status?: boolean;
+}
+
+export const userService = {
+  getById: (id: number) => api.get<UserDto>(`/api/users/${id}`),
+  list: (page: PageRequest) =>
+    api.get<PaginatedResponse<UserDto>>(`/api/users?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`),
+  create: (data: Omit<UserDto, 'id'> & { password: string }) =>
+    api.post<UserDto>('/api/users', data),
+  update: (data: UserDto) => api.put<UserDto>('/api/users', data),
+  delete: (id: number) => api.delete<unknown>(`/api/users/${id}`),
+};
+


### PR DESCRIPTION
## Summary
- add generic API client and service modules
- wire auth store to real login API
- fetch templates and tags from backend services
- hook tag and dashboard views to API data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e6bb69e408324a7d906f19afe0e71