### PR TITLE
Add new API services and list components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import { TagList } from './components/Tags/TagList';
 import { UserList } from './components/Users/UserList';
 import { LogList } from './components/Logs/LogList';
 import { Settings } from './components/Settings/Settings';
+import { InstantValueList } from './components/InstantValues/InstantValueList';
+import { OperationClaimList } from './components/OperationClaims/OperationClaimList';
 import { authStore } from './store/authStore';
 
 function App() {
@@ -32,6 +34,10 @@ function App() {
         return <TemplateList />;
       case 'tags':
         return <TagList />;
+      case 'instantvalues':
+        return <InstantValueList />;
+      case 'operationclaims':
+        return <OperationClaimList />;
       case 'users':
         return <UserList />;
       case 'logs':

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -12,11 +12,11 @@ import {
 import { DashboardCard } from './DashboardCard';
 import { SystemStatus } from './SystemStatus';
 import { DataChart } from './DataChart';
-import { dashboardService } from '../../services';
+import { dashboardService, DashboardStats, SystemMetric } from '../../services';
 
 export const Dashboard: React.FC = () => {
-  const [stats, setStats] = useState(dashboardService.stats as any);
-  const [systemMetrics, setSystemMetrics] = useState([] as any[]);
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [systemMetrics, setSystemMetrics] = useState<SystemMetric[]>([]);
 
   useEffect(() => {
     dashboardService.stats().then(setStats);

--- a/src/components/InstantValues/InstantValueList.tsx
+++ b/src/components/InstantValues/InstantValueList.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { instantValueService, InstantValueDto } from '../../services';
+
+export const InstantValueList: React.FC = () => {
+  const [values, setValues] = useState<InstantValueDto[]>([]);
+
+  useEffect(() => {
+    instantValueService
+      .list({ pageNumber: 0, pageSize: 50 })
+      .then((res) => setValues(res.items))
+      .catch(() => setValues([]));
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-gray-900">Anlık Değerler</h1>
+      </div>
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Zaman Damgası
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Tag Id
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Değer
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Durum
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {values.map((val) => (
+                <tr key={val.timestamp + val.reportTemplateTagId} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {val.timestamp}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {val.reportTemplateTagId}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {val.value}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {val.status}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {values.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-gray-500">Hiç veri bulunamadı.</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { 
-  BarChart3, 
-  FileText, 
-  Tags, 
-  Users, 
-  Settings, 
+import {
+  BarChart3,
+  FileText,
+  Tags,
+  Users,
+  Settings,
   Activity,
-  Shield
+  Shield,
+  Database,
+  Key
 } from 'lucide-react';
 import { authStore } from '../../store/authStore';
 
@@ -17,12 +19,13 @@ interface SidebarProps {
 
 export const Sidebar: React.FC<SidebarProps> = ({ activeTab, onTabChange }) => {
   const currentUser = authStore.getCurrentUser();
-  const isAdmin = currentUser?.role === 'admin';
 
   const menuItems = [
     { id: 'dashboard', label: 'Dashboard', icon: BarChart3, roles: ['admin', 'operator'] },
     { id: 'templates', label: 'Rapor Şablonları', icon: FileText, roles: ['admin', 'operator'] },
     { id: 'tags', label: 'Etiketler', icon: Tags, roles: ['admin', 'operator'] },
+    { id: 'instantvalues', label: 'Anlık Değerler', icon: Database, roles: ['admin', 'operator'] },
+    { id: 'operationclaims', label: 'Yetkiler', icon: Key, roles: ['admin'] },
     { id: 'users', label: 'Kullanıcı Yönetimi', icon: Users, roles: ['admin'] },
     { id: 'logs', label: 'Sistem Logları', icon: Shield, roles: ['admin'] },
     { id: 'settings', label: 'Ayarlar', icon: Settings, roles: ['admin'] }

--- a/src/components/Logs/LogList.tsx
+++ b/src/components/Logs/LogList.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const LogList: React.FC = () => (
+  <div className="text-center py-12">
+    <p className="text-gray-500">Log bileşeni henüz uygulanmadı.</p>
+  </div>
+);

--- a/src/components/OperationClaims/OperationClaimList.tsx
+++ b/src/components/OperationClaims/OperationClaimList.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import { OperationClaimDto, operationClaimService } from '../../services';
+
+export const OperationClaimList: React.FC = () => {
+  const [claims, setClaims] = useState<OperationClaimDto[]>([]);
+
+  useEffect(() => {
+    operationClaimService
+      .list({ pageNumber: 0, pageSize: 50 })
+      .then((res) => setClaims(res.items))
+      .catch(() => setClaims([]));
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-gray-900">Yetkiler</h1>
+      </div>
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  İsim
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {claims.map((claim) => (
+                <tr key={claim.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {claim.name}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {claims.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-gray-500">Hiç yetki bulunamadı.</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -7,7 +7,7 @@ export const TemplateList: React.FC = () => {
   const [templates, setTemplates] = useState<ReportTemplate[]>([]);
   const [tags, setTags] = useState<Record<string, number>>({});
   const [searchTerm, setSearchTerm] = useState('');
-  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [, setShowCreateForm] = useState(false);
 
   useEffect(() => {
     templateService
@@ -47,7 +47,7 @@ export const TemplateList: React.FC = () => {
 
   const handleDelete = async (id: string) => {
     if (window.confirm('Bu şablonu silmek istediğinizden emin misiniz?')) {
-      await templateService.delete(id as any);
+      await templateService.delete(Number(id));
       templateService
         .list({ pageNumber: 0, pageSize: 50 })
         .then((res) => setTemplates(res.items));

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,9 +17,9 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
 
 export const api = {
   get: <T>(url: string) => request<T>(url),
-  post: <T>(url: string, body?: any) =>
+  post: <T>(url: string, body?: unknown) =>
     request<T>(url, { method: 'POST', body: JSON.stringify(body) }),
-  put: <T>(url: string, body?: any) =>
+  put: <T>(url: string, body?: unknown) =>
     request<T>(url, { method: 'PUT', body: JSON.stringify(body) }),
   delete: <T>(url: string) => request<T>(url, { method: 'DELETE' }),
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -4,3 +4,6 @@ export * from './templateService';
 export * from './tagService';
 export * from './userService';
 export * from './dashboardService';
+export * from './operationClaimService';
+export * from './userOperationClaimService';
+export * from './instantValueService';

--- a/src/services/instantValueService.ts
+++ b/src/services/instantValueService.ts
@@ -1,0 +1,21 @@
+import { api } from './api';
+import { PageRequest, PaginatedResponse } from './templateService';
+
+export interface InstantValueDto {
+  timestamp: string;
+  reportTemplateTagId: number;
+  value: number | string;
+  status: string;
+}
+
+export const instantValueService = {
+  create: (data: InstantValueDto) =>
+    api.post<InstantValueDto>('/api/instantvalues', data),
+  getByTimestamp: (timestamp: string) =>
+    api.get<InstantValueDto>(`/api/instantvalues/${timestamp}`),
+  list: (page: PageRequest, query?: unknown) =>
+    api.post<PaginatedResponse<InstantValueDto>>(
+      `/api/instantvalues/list?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`,
+      query ?? {}
+    ),
+};

--- a/src/services/operationClaimService.ts
+++ b/src/services/operationClaimService.ts
@@ -1,0 +1,21 @@
+import { api } from './api';
+import { PageRequest, PaginatedResponse } from './templateService';
+
+export interface OperationClaimDto {
+  id: number;
+  name: string;
+}
+
+export const operationClaimService = {
+  getById: (id: number) =>
+    api.get<OperationClaimDto>(`/api/operationclaims/${id}`),
+  list: (page: PageRequest) =>
+    api.get<PaginatedResponse<OperationClaimDto>>(
+      `/api/operationclaims?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`
+    ),
+  create: (data: Omit<OperationClaimDto, 'id'>) =>
+    api.post<OperationClaimDto>('/api/operationclaims', data),
+  update: (data: OperationClaimDto) =>
+    api.put<OperationClaimDto>('/api/operationclaims', data),
+  delete: (id: number) => api.delete<unknown>(`/api/operationclaims/${id}`),
+};

--- a/src/services/userOperationClaimService.ts
+++ b/src/services/userOperationClaimService.ts
@@ -1,0 +1,22 @@
+import { api } from './api';
+import { PageRequest, PaginatedResponse } from './templateService';
+
+export interface UserOperationClaimDto {
+  id: number;
+  userId: number;
+  operationClaimId: number;
+}
+
+export const userOperationClaimService = {
+  getById: (id: number) =>
+    api.get<UserOperationClaimDto>(`/api/useroperationclaims/${id}`),
+  list: (page: PageRequest) =>
+    api.get<PaginatedResponse<UserOperationClaimDto>>(
+      `/api/useroperationclaims?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`
+    ),
+  create: (data: Omit<UserOperationClaimDto, 'id'>) =>
+    api.post<UserOperationClaimDto>('/api/useroperationclaims', data),
+  update: (data: UserOperationClaimDto) =>
+    api.put<UserOperationClaimDto>('/api/useroperationclaims', data),
+  delete: (id: number) => api.delete<unknown>(`/api/useroperationclaims/${id}`),
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,7 +34,7 @@ export interface ReportTemplateTag {
 export interface InstantValue {
   id: string;
   tagId: string;
-  value: any;
+  value: string | number | boolean;
   quality: 'good' | 'bad' | 'uncertain';
   timestamp: string;
 }


### PR DESCRIPTION
## Summary
- implement API service modules for operation claims, user operation claims and instant values
- export new services from service index
- create list components for instant values, operation claims and logs placeholder
- update sidebar and app navigation to include new pages
- clean up linter warnings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e73f0e68883248fcfd121dc898b9d