### PR TITLE
Connect UI to backend API

### DIFF
--- a/src/components/Users/UserList.tsx
+++ b/src/components/Users/UserList.tsx
@@ -1,36 +1,28 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Plus, Search, UserCheck, UserX, Edit2 } from 'lucide-react';
 import { User } from '../../types';
+import { userService } from '../../services';
 
 export const UserList: React.FC = () => {
-  const [users, setUsers] = useState<User[]>([
-    {
-      id: '1',
-      username: 'admin',
-      email: 'admin@iski.gov.tr',
-      role: 'admin',
-      createdAt: '2024-01-01T00:00:00Z',
-      lastLogin: '2024-01-15T10:30:00Z',
-      isActive: true
-    },
-    {
-      id: '2',
-      username: 'operator1',
-      email: 'operator1@iski.gov.tr',
-      role: 'operator',
-      createdAt: '2024-01-02T00:00:00Z',
-      lastLogin: '2024-01-15T09:15:00Z',
-      isActive: true
-    },
-    {
-      id: '3',
-      username: 'yeni_kullanici',
-      email: 'yeni@iski.gov.tr',
-      role: 'pending',
-      createdAt: '2024-01-15T08:00:00Z',
-      isActive: false
-    }
-  ]);
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    userService
+      .list({ pageNumber: 0, pageSize: 50 })
+      .then((res) =>
+        setUsers(
+          res.items.map((u) => ({
+            id: u.id.toString(),
+            username: `${u.firstName} ${u.lastName}`,
+            email: u.email,
+            role: 'operator',
+            createdAt: new Date().toISOString(),
+            isActive: u.status ?? true,
+          }))
+        )
+      )
+      .catch(() => setUsers([]));
+  }, []);
 
   const [searchTerm, setSearchTerm] = useState('');
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,9 +1,12 @@
-const API_URL = import.meta.env.VITE_API_URL || '';
+import { authStore } from '../store/authStore';
+const API_URL = import.meta.env.VITE_API_URL || 'https://localhost:444';
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const token = authStore.getAccessToken();
   const response = await fetch(API_URL + url, {
     headers: {
       'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...options.headers,
     },
     ...options,

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -9,6 +9,12 @@ export interface UserDto {
   status?: boolean;
 }
 
+export interface ChangePasswordDto {
+  userId: number;
+  oldPassword: string;
+  newPassword: string;
+}
+
 export const userService = {
   getById: (id: number) => api.get<UserDto>(`/api/users/${id}`),
   list: (page: PageRequest) =>
@@ -17,5 +23,7 @@ export const userService = {
     api.post<UserDto>('/api/users', data),
   update: (data: UserDto) => api.put<UserDto>('/api/users', data),
   delete: (id: number) => api.delete<unknown>(`/api/users/${id}`),
+  changePassword: (data: ChangePasswordDto) =>
+    api.put<unknown>('/api/users/change-password', data),
 };
 


### PR DESCRIPTION
## Summary
- add auth token support in api service and set default API base url to `https://localhost:444`
- expose change password request in `userService`
- load user list from backend instead of static data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f687f327c8324b7a7754348036719