### PR TITLE
Fix login fallback and dashboard error

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -13,14 +13,21 @@ import { DashboardCard } from './DashboardCard';
 import { SystemStatus } from './SystemStatus';
 import { DataChart } from './DataChart';
 import { dashboardService, DashboardStats, SystemMetric } from '../../services';
+import { dataStore } from '../../store/dataStore';
 
 export const Dashboard: React.FC = () => {
-  const [stats, setStats] = useState<DashboardStats | null>(null);
-  const [systemMetrics, setSystemMetrics] = useState<SystemMetric[]>([]);
+  const [stats, setStats] = useState<DashboardStats>(dataStore.getDashboardStats());
+  const [systemMetrics, setSystemMetrics] = useState<SystemMetric[]>(dataStore.getSystemMetrics());
 
   useEffect(() => {
-    dashboardService.stats().then(setStats);
-    dashboardService.metrics().then(setSystemMetrics);
+    dashboardService
+      .stats()
+      .then(setStats)
+      .catch(() => setStats(dataStore.getDashboardStats()));
+    dashboardService
+      .metrics()
+      .then(setSystemMetrics)
+      .catch(() => setSystemMetrics(dataStore.getSystemMetrics()));
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- add offline admin account support to auth store
- handle dashboard stats when backend is unreachable

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fa02eba9c8324a7eb86c09b4bcfec