### PR TITLE
Fix API configuration and update tag/template pages

### DIFF
--- a/src/components/Tags/TagList.tsx
+++ b/src/components/Tags/TagList.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Search, Filter } from 'lucide-react';
-import { ReportTemplateTag } from '../../types';
-import { tagService, templateService } from '../../services';
+import {
+  tagService,
+  templateService,
+  ReportTemplateTagDto,
+  ReportTemplateDto,
+} from '../../services';
 
 export const TagList: React.FC = () => {
-  const [tags, setTags] = useState<ReportTemplateTag[]>([]);
-  const [templates, setTemplates] = useState<{ id: number; name: string }[]>([]);
+  const [tags, setTags] = useState<ReportTemplateTagDto[]>([]);
+  const [templates, setTemplates] = useState<ReportTemplateDto[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTemplate, setSelectedTemplate] = useState<string>('all');
 
@@ -18,30 +22,20 @@ export const TagList: React.FC = () => {
       .then((res) => setTemplates(res.items));
   }, []);
 
-  const filteredTags = tags.filter(tag => {
-    const matchesSearch = tag.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         tag.description?.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesTemplate = selectedTemplate === 'all' || tag.templateId === selectedTemplate;
+  const filteredTags = tags.filter((tag) => {
+    const matchesSearch = tag.tagName
+      .toLowerCase()
+      .includes(searchTerm.toLowerCase());
+    const matchesTemplate =
+      selectedTemplate === 'all' || tag.reportTemplateId === Number(selectedTemplate);
     return matchesSearch && matchesTemplate;
   });
 
-  const getTemplateName = (templateId: string | number) => {
-    const template = templates.find(t => t.id === Number(templateId));
+  const getTemplateName = (templateId: number) => {
+    const template = templates.find((t) => t.id === templateId);
     return template?.name || 'Bilinmiyor';
   };
 
-  const getDataTypeColor = (type: string) => {
-    switch (type) {
-      case 'number':
-        return 'bg-blue-100 text-blue-800';
-      case 'boolean':
-        return 'bg-green-100 text-green-800';
-      case 'string':
-        return 'bg-purple-100 text-purple-800';
-      default:
-        return 'bg-gray-100 text-gray-800';
-    }
-  };
 
   return (
     <div className="space-y-6">
@@ -73,8 +67,10 @@ export const TagList: React.FC = () => {
             className="pl-10 pr-8 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="all">Tüm Şablonlar</option>
-            {templates.map(template => (
-              <option key={template.id} value={template.id}>{template.name}</option>
+            {templates.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.name}
+              </option>
             ))}
           </select>
         </div>
@@ -95,48 +91,19 @@ export const TagList: React.FC = () => {
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Node ID
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Veri Tipi
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Birim
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Durum
-                </th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
               {filteredTags.map((tag) => (
                 <tr key={tag.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div>
-                      <div className="text-sm font-medium text-gray-900">{tag.name}</div>
-                      {tag.description && (
-                        <div className="text-sm text-gray-500">{tag.description}</div>
-                      )}
-                    </div>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {tag.tagName}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {getTemplateName(tag.templateId)}
+                    {getTemplateName(tag.reportTemplateId)}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-600">
-                    {tag.nodeId}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span className={`inline-flex px-2 py-1 text-xs rounded-full ${getDataTypeColor(tag.dataType)}`}>
-                      {tag.dataType}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {tag.unit || '-'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span className={`inline-flex px-2 py-1 text-xs rounded-full ${
-                      tag.isActive ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
-                    }`}>
-                      {tag.isActive ? 'Aktif' : 'Pasif'}
-                    </span>
+                    {tag.tagNodeId}
                   </td>
                 </tr>
               ))}
@@ -151,4 +118,5 @@ export const TagList: React.FC = () => {
         </div>
       )}
     </div>
-  );};
+  );
+};

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Edit2, Trash2, Power, Search } from 'lucide-react';
-import { ReportTemplate } from '../../types';
-import { templateService, tagService } from '../../services';
+import {
+  templateService,
+  tagService,
+  ReportTemplateDto,
+} from '../../services';
 
 export const TemplateList: React.FC = () => {
-  const [templates, setTemplates] = useState<ReportTemplate[]>([]);
+  const [templates, setTemplates] = useState<ReportTemplateDto[]>([]);
   const [tags, setTags] = useState<Record<string, number>>({});
   const [searchTerm, setSearchTerm] = useState('');
   const [, setShowCreateForm] = useState(false);
@@ -25,19 +28,15 @@ export const TemplateList: React.FC = () => {
       });
   }, []);
 
-  const filteredTemplates = templates.filter(template =>
-    template.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    template.description.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredTemplates = templates.filter((template) =>
+    template.name.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  const handleToggleActive = async (id: string) => {
+  const handleToggleActive = async (id: number) => {
     const template = templates.find((t) => t.id === id);
     if (!template) return;
     try {
-      await templateService.update({
-        ...template,
-        isActive: !template.isActive,
-      });
+      await templateService.update({ ...template, isActive: !template.isActive });
     } finally {
       templateService
         .list({ pageNumber: 0, pageSize: 50 })
@@ -45,7 +44,7 @@ export const TemplateList: React.FC = () => {
     }
   };
 
-  const handleDelete = async (id: string) => {
+  const handleDelete = async (id: number) => {
     if (window.confirm('Bu şablonu silmek istediğinizden emin misiniz?')) {
       await templateService.delete(Number(id));
       templateService
@@ -82,11 +81,14 @@ export const TemplateList: React.FC = () => {
       {/* Templates Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {filteredTemplates.map((template) => (
-          <div key={template.id} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div
+            key={template.id}
+            className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+          >
             <div className="flex items-start justify-between mb-4">
               <div>
                 <h3 className="text-lg font-semibold text-gray-900">{template.name}</h3>
-                <p className="text-sm text-gray-500 mt-1">{template.description}</p>
+                {/* description not provided by API */}
               </div>
               <div className="flex items-center space-x-2">
                 <button
@@ -117,8 +119,8 @@ export const TemplateList: React.FC = () => {
                 <span className="font-mono text-xs">{template.opcEndpoint}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-600">Toplama Aralığı:</span>
-                <span>{template.collectionInterval}s</span>
+                <span className="text-gray-600">Çekme Aralığı:</span>
+                <span>{template.pullInterval}s</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600">Etiket Sayısı:</span>
@@ -136,12 +138,7 @@ export const TemplateList: React.FC = () => {
               </div>
             </div>
 
-            <div className="mt-4 pt-4 border-t border-gray-200">
-              <div className="flex items-center justify-between text-xs text-gray-500">
-                <span>Oluşturan: {template.createdBy}</span>
-                <span>{new Date(template.createdAt).toLocaleDateString('tr-TR')}</span>
-              </div>
-            </div>
+            {/* metadata like creator or date not provided by API */}
           </div>
         ))}
       </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import { authStore } from '../store/authStore';
-const API_URL = import.meta.env.VITE_API_URL || 'https://localhost:444';
+const API_URL = (import.meta.env.VITE_API_URL || 'https://localhost:444/')
+  .replace(/\/+$/, '');
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   const token = authStore.getAccessToken();

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -16,5 +16,8 @@ export const tagService = {
     api.put<ReportTemplateTagDto>('/api/reporttemplatetags', data),
   delete: (id: number) => api.delete<unknown>(`/api/reporttemplatetags/${id}`),
   list: (page: PageRequest) =>
-    api.post<PaginatedResponse<ReportTemplateTagDto>>('/api/reporttemplatetags/list?pageIndex=' + page.pageNumber + '&pageSize=' + page.pageSize, {}),
+    api.post<PaginatedResponse<ReportTemplateTagDto>>(
+      `/api/reporttemplatetags/list?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`,
+      {}
+    ),
 };

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -28,5 +28,8 @@ export const templateService = {
     api.put<ReportTemplateDto>('/api/reporttemplates', data),
   delete: (id: number) => api.delete<unknown>(`/api/reporttemplates/${id}`),
   list: (page: PageRequest) =>
-    api.post<PaginatedResponse<ReportTemplateDto>>('/api/reporttemplates/list?pageIndex=' + page.pageNumber + '&pageSize=' + page.pageSize, {}),
+    api.post<PaginatedResponse<ReportTemplateDto>>(
+      `/api/reporttemplates/list?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`,
+      {}
+    ),
 };


### PR DESCRIPTION
## Summary
- sanitize API base URL and set default to https://localhost:444/
- fix paging query params in template/tag services
- align TemplateList and TagList components with API DTOs

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870af861300832484ae4e63874e10a4