### PR TITLE
Add UserOperationClaim list page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { LogList } from './components/Logs/LogList';
 import { Settings } from './components/Settings/Settings';
 import { InstantValueList } from './components/InstantValues/InstantValueList';
 import { OperationClaimList } from './components/OperationClaims/OperationClaimList';
+import { UserOperationClaimList } from './components/UserOperationClaims/UserOperationClaimList';
 import { authStore } from './store/authStore';
 
 function App() {
@@ -38,6 +39,8 @@ function App() {
         return <InstantValueList />;
       case 'operationclaims':
         return <OperationClaimList />;
+      case 'useroperationclaims':
+        return <UserOperationClaimList />;
       case 'users':
         return <UserList />;
       case 'logs':

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -8,7 +8,8 @@ import {
   Activity,
   Shield,
   Database,
-  Key
+  Key,
+  UserCog
 } from 'lucide-react';
 import { authStore } from '../../store/authStore';
 
@@ -26,6 +27,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeTab, onTabChange }) => {
     { id: 'tags', label: 'Etiketler', icon: Tags, roles: ['admin', 'operator'] },
     { id: 'instantvalues', label: 'Anlık Değerler', icon: Database, roles: ['admin', 'operator'] },
     { id: 'operationclaims', label: 'Yetkiler', icon: Key, roles: ['admin'] },
+    { id: 'useroperationclaims', label: 'Kullanıcı Yetkileri', icon: UserCog, roles: ['admin'] },
     { id: 'users', label: 'Kullanıcı Yönetimi', icon: Users, roles: ['admin'] },
     { id: 'logs', label: 'Sistem Logları', icon: Shield, roles: ['admin'] },
     { id: 'settings', label: 'Ayarlar', icon: Settings, roles: ['admin'] }

--- a/src/components/UserOperationClaims/UserOperationClaimList.tsx
+++ b/src/components/UserOperationClaims/UserOperationClaimList.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { userOperationClaimService, UserOperationClaimDto } from '../../services';
+
+export const UserOperationClaimList: React.FC = () => {
+  const [claims, setClaims] = useState<UserOperationClaimDto[]>([]);
+
+  useEffect(() => {
+    userOperationClaimService
+      .list({ pageNumber: 0, pageSize: 50 })
+      .then((res) => setClaims(res.items))
+      .catch(() => setClaims([]));
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-gray-900">Kullanıcı Yetkileri</h1>
+      </div>
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Kullanıcı ID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Yetki ID
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {claims.map((claim) => (
+                <tr key={claim.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{claim.id}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{claim.userId}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{claim.operationClaimId}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {claims.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-gray-500">Hiç yetki ataması bulunamadı.</p>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add component to list user-operation claim assignments
- add menu entry and route for the new component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870b3c61c608324a9c2a60087aecc7a