### PR TITLE
Implement dynamic query support

### DIFF
--- a/src/components/InstantValues/InstantValueList.tsx
+++ b/src/components/InstantValues/InstantValueList.tsx
@@ -6,7 +6,7 @@ export const InstantValueList: React.FC = () => {
 
   useEffect(() => {
     instantValueService
-      .list({ pageNumber: 0, pageSize: 50 })
+      .list({ index: 0, size: 50 })
       .then((res) => setValues(res.items))
       .catch(() => setValues([]));
   }, []);

--- a/src/components/OperationClaims/OperationClaimList.tsx
+++ b/src/components/OperationClaims/OperationClaimList.tsx
@@ -6,7 +6,7 @@ export const OperationClaimList: React.FC = () => {
 
   useEffect(() => {
     operationClaimService
-      .list({ pageNumber: 0, pageSize: 50 })
+      .list({ index: 0, size: 50 })
       .then((res) => setClaims(res.items))
       .catch(() => setClaims([]));
   }, []);

--- a/src/components/Tags/TagList.tsx
+++ b/src/components/Tags/TagList.tsx
@@ -15,10 +15,10 @@ export const TagList: React.FC = () => {
 
   useEffect(() => {
     tagService
-      .list({ pageNumber: 0, pageSize: 100 })
+      .list({ index: 0, size: 100 })
       .then((res) => setTags(res.items));
     templateService
-      .list({ pageNumber: 0, pageSize: 50 })
+      .list({ index: 0, size: 50 })
       .then((res) => setTemplates(res.items));
   }, []);
 

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -14,11 +14,11 @@ export const TemplateList: React.FC = () => {
 
   const loadData = () => {
     templateService
-      .list({ pageNumber: 0, pageSize: 50 })
+      .list({ index: 0, size: 50 })
       .then((res) => setTemplates(res.items))
       .catch(() => setTemplates([]));
     tagService
-      .list({ pageNumber: 0, pageSize: 100 })
+      .list({ index: 0, size: 100 })
       .then((res) => {
         const grouped: Record<string, number> = {};
         res.items.forEach((t) => {
@@ -43,7 +43,7 @@ export const TemplateList: React.FC = () => {
       await templateService.update({ ...template, isActive: !template.isActive });
     } finally {
       templateService
-        .list({ pageNumber: 0, pageSize: 50 })
+        .list({ index: 0, size: 50 })
         .then((res) => setTemplates(res.items));
     }
   };
@@ -56,7 +56,7 @@ export const TemplateList: React.FC = () => {
     if (window.confirm('Bu şablonu silmek istediğinizden emin misiniz?')) {
       await templateService.delete(Number(id));
       templateService
-        .list({ pageNumber: 0, pageSize: 50 })
+        .list({ index: 0, size: 50 })
         .then((res) => setTemplates(res.items));
     }
   };

--- a/src/components/UserOperationClaims/UserOperationClaimList.tsx
+++ b/src/components/UserOperationClaims/UserOperationClaimList.tsx
@@ -6,7 +6,7 @@ export const UserOperationClaimList: React.FC = () => {
 
   useEffect(() => {
     userOperationClaimService
-      .list({ pageNumber: 0, pageSize: 50 })
+      .list({ index: 0, size: 50 })
       .then((res) => setClaims(res.items))
       .catch(() => setClaims([]));
   }, []);

--- a/src/components/Users/UserList.tsx
+++ b/src/components/Users/UserList.tsx
@@ -8,7 +8,7 @@ export const UserList: React.FC = () => {
 
   const loadData = () => {
     userService
-      .list({ pageNumber: 0, pageSize: 50 })
+      .list({ index: 0, size: 50 })
       .then((res) =>
         setUsers(
           res.items.map((u) => ({

--- a/src/services/instantValueService.ts
+++ b/src/services/instantValueService.ts
@@ -1,5 +1,5 @@
 import { api } from './api';
-import { PageRequest, PaginatedResponse } from './templateService';
+import { PageRequest, PaginatedResponse, DynamicQuery } from './templateService';
 
 export interface InstantValueDto {
   timestamp: string;
@@ -13,9 +13,9 @@ export const instantValueService = {
     api.post<InstantValueDto>('/api/instantvalues', data),
   getByTimestamp: (timestamp: string) =>
     api.get<InstantValueDto>(`/api/instantvalues/${timestamp}`),
-  list: (page: PageRequest, query?: unknown) =>
+  list: (page: PageRequest, query?: DynamicQuery) =>
     api.post<PaginatedResponse<InstantValueDto>>(
-      `/api/instantvalues/list?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`,
+      `/api/instantvalues/list?pageNumber=${page.index}&pageSize=${page.size}`,
       query ?? {}
     ),
 };

--- a/src/services/operationClaimService.ts
+++ b/src/services/operationClaimService.ts
@@ -1,5 +1,5 @@
 import { api } from './api';
-import { PageRequest, PaginatedResponse } from './templateService';
+import { PageRequest, PaginatedResponse, DynamicQuery } from './templateService';
 
 export interface OperationClaimDto {
   id: number;
@@ -9,9 +9,10 @@ export interface OperationClaimDto {
 export const operationClaimService = {
   getById: (id: number) =>
     api.get<OperationClaimDto>(`/api/operationclaims/${id}`),
-  list: (page: PageRequest) =>
-    api.get<PaginatedResponse<OperationClaimDto>>(
-      `/api/operationclaims?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`
+  list: (page: PageRequest, query?: DynamicQuery) =>
+    api.post<PaginatedResponse<OperationClaimDto>>(
+      `/api/operationclaims/list?pageNumber=${page.index}&pageSize=${page.size}`,
+      query ?? {}
     ),
   create: (data: Omit<OperationClaimDto, 'id'>) =>
     api.post<OperationClaimDto>('/api/operationclaims', data),

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -1,5 +1,5 @@
 import { api } from './api';
-import { PageRequest, PaginatedResponse } from './templateService';
+import { PageRequest, PaginatedResponse, DynamicQuery } from './templateService';
 
 export interface ReportTemplateTagDto {
   id: number;
@@ -15,9 +15,9 @@ export const tagService = {
   update: (data: ReportTemplateTagDto) =>
     api.put<ReportTemplateTagDto>('/api/reporttemplatetags', data),
   delete: (id: number) => api.delete<unknown>(`/api/reporttemplatetags/${id}`),
-  list: (page: PageRequest) =>
+  list: (page: PageRequest, query?: DynamicQuery) =>
     api.post<PaginatedResponse<ReportTemplateTagDto>>(
-      `/api/reporttemplatetags/list?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`,
-      {}
+      `/api/reporttemplatetags/list?pageNumber=${page.index}&pageSize=${page.size}`,
+      query ?? {}
     ),
 };

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -9,15 +9,23 @@ export interface ReportTemplateDto {
 }
 
 export interface PageRequest {
-  pageNumber: number;
-  pageSize: number;
+  index: number;
+  size: number;
+}
+
+export interface DynamicQuery {
+  filters?: Array<{ field: string; operator: string; value: string }>;
+  sorts?: Array<{ field: string; direction: string }>;
 }
 
 export interface PaginatedResponse<T> {
   items: T[];
-  pageIndex: number;
-  pageSize: number;
+  index: number;
+  size: number;
   count: number;
+  pages: number;
+  hasPrevious: boolean;
+  hasNext: boolean;
 }
 
 export const templateService = {
@@ -27,9 +35,9 @@ export const templateService = {
   update: (data: ReportTemplateDto) =>
     api.put<ReportTemplateDto>('/api/reporttemplates', data),
   delete: (id: number) => api.delete<unknown>(`/api/reporttemplates/${id}`),
-  list: (page: PageRequest) =>
+  list: (page: PageRequest, query?: DynamicQuery) =>
     api.post<PaginatedResponse<ReportTemplateDto>>(
-      `/api/reporttemplates/list?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`,
-      {}
+      `/api/reporttemplates/list?pageNumber=${page.index}&pageSize=${page.size}`,
+      query ?? {}
     ),
 };

--- a/src/services/userOperationClaimService.ts
+++ b/src/services/userOperationClaimService.ts
@@ -1,5 +1,5 @@
 import { api } from './api';
-import { PageRequest, PaginatedResponse } from './templateService';
+import { PageRequest, PaginatedResponse, DynamicQuery } from './templateService';
 
 export interface UserOperationClaimDto {
   id: number;
@@ -10,9 +10,10 @@ export interface UserOperationClaimDto {
 export const userOperationClaimService = {
   getById: (id: number) =>
     api.get<UserOperationClaimDto>(`/api/useroperationclaims/${id}`),
-  list: (page: PageRequest) =>
-    api.get<PaginatedResponse<UserOperationClaimDto>>(
-      `/api/useroperationclaims?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`
+  list: (page: PageRequest, query?: DynamicQuery) =>
+    api.post<PaginatedResponse<UserOperationClaimDto>>(
+      `/api/useroperationclaims/list?pageNumber=${page.index}&pageSize=${page.size}`,
+      query ?? {}
     ),
   create: (data: Omit<UserOperationClaimDto, 'id'>) =>
     api.post<UserOperationClaimDto>('/api/useroperationclaims', data),

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,5 +1,5 @@
 import { api } from './api';
-import { PageRequest, PaginatedResponse } from './templateService';
+import { PageRequest, PaginatedResponse, DynamicQuery } from './templateService';
 
 export interface UserDto {
   id: number;
@@ -17,8 +17,11 @@ export interface ChangePasswordDto {
 
 export const userService = {
   getById: (id: number) => api.get<UserDto>(`/api/users/${id}`),
-  list: (page: PageRequest) =>
-    api.get<PaginatedResponse<UserDto>>(`/api/users?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`),
+  list: (page: PageRequest, query?: DynamicQuery) =>
+    api.post<PaginatedResponse<UserDto>>(
+      `/api/users/list?pageNumber=${page.index}&pageSize=${page.size}`,
+      query ?? {}
+    ),
   create: (data: Omit<UserDto, 'id'> & { password: string }) =>
     api.post<UserDto>('/api/users', data),
   update: (data: UserDto) => api.put<UserDto>('/api/users', data),


### PR DESCRIPTION
## Summary
- add dynamic query types and pagination fields
- update list requests in services to use dynamic query
- adjust components to use new list API

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870cdd5db9c83248220772b207cc507