### PR TITLE
Handle user ID from token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { LoginForm } from './components/Auth/LoginForm';
-import { Header } from './components/Layout/Header';
-import { Sidebar } from './components/Layout/Sidebar';
+import { MainLayout } from './components/Layout/MainLayout';
 import { Dashboard } from './components/Dashboard/Dashboard';
 import { TemplateList } from './components/Templates/TemplateList';
 import { TagList } from './components/Tags/TagList';
@@ -11,6 +10,7 @@ import { Settings } from './components/Settings/Settings';
 import { InstantValueList } from './components/InstantValues/InstantValueList';
 import { OperationClaimList } from './components/OperationClaims/OperationClaimList';
 import { UserOperationClaimList } from './components/UserOperationClaims/UserOperationClaimList';
+import { UserSettings } from './components/Users/UserSettings';
 import { authStore } from './store/authStore';
 
 function App() {
@@ -47,6 +47,8 @@ function App() {
         return <LogList />;
       case 'settings':
         return <Settings />;
+      case 'user-settings':
+        return <UserSettings />;
       default:
         return <Dashboard />;
     }
@@ -57,17 +59,14 @@ function App() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <Header onLogout={handleLogout} />
-      <div className="flex">
-        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-        <main className="flex-1 p-6">
-          <div className="max-w-7xl mx-auto">
-            {renderContent()}
-          </div>
-        </main>
-      </div>
-    </div>
+    <MainLayout
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+      onLogout={handleLogout}
+      onOpenUserSettings={() => setActiveTab('user-settings')}
+    >
+      {renderContent()}
+    </MainLayout>
   );
 }
 

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -4,9 +4,10 @@ import { authStore } from '../../store/authStore';
 
 interface HeaderProps {
   onLogout: () => void;
+  onOpenUserSettings: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ onLogout }) => {
+export const Header: React.FC<HeaderProps> = ({ onLogout, onOpenUserSettings }) => {
   const currentUser = authStore.getCurrentUser();
 
   return (
@@ -26,13 +27,16 @@ export const Header: React.FC<HeaderProps> = ({ onLogout }) => {
           </div>
 
           <div className="flex items-center space-x-4">
-            <div className="flex items-center space-x-2">
+            <button
+              onClick={onOpenUserSettings}
+              className="flex items-center space-x-2 focus:outline-none hover:bg-gray-100 px-2 py-1 rounded-md"
+            >
               <User className="h-5 w-5 text-gray-400" />
-              <div className="text-sm">
+              <div className="text-sm text-left">
                 <div className="font-medium text-gray-900">{currentUser?.username}</div>
                 <div className="text-gray-500 capitalize">{currentUser?.role}</div>
               </div>
-            </div>
+            </button>
             <button
               onClick={onLogout}
               className="flex items-center space-x-2 px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 transition-colors"

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Header } from './Header';
+import { Sidebar } from './Sidebar';
+
+interface MainLayoutProps {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+  onLogout: () => void;
+  onOpenUserSettings: () => void;
+  children: React.ReactNode;
+}
+
+export const MainLayout: React.FC<MainLayoutProps> = ({
+  activeTab,
+  onTabChange,
+  onLogout,
+  onOpenUserSettings,
+  children,
+}) => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header onLogout={onLogout} onOpenUserSettings={onOpenUserSettings} />
+      <div className="flex">
+        <Sidebar activeTab={activeTab} onTabChange={onTabChange} />
+        <main className="flex-1 p-6">
+          <div className="max-w-7xl mx-auto">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Users/UserSettings.tsx
+++ b/src/components/Users/UserSettings.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { userService, UserDto } from '../../services';
+import { authStore } from '../../store/authStore';
+
+export const UserSettings: React.FC = () => {
+  const currentUser = authStore.getCurrentUser();
+  const [user, setUser] = useState<UserDto | null>(null);
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!currentUser) return;
+    userService
+      .getById(currentUser.id)
+      .then((u) => setUser(u))
+      .catch(() => setUser(null));
+  }, [currentUser]);
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!currentUser) return;
+    if (newPassword !== confirmPassword) {
+      setMessage('Yeni şifreler uyuşmuyor');
+      return;
+    }
+    try {
+      await userService.changePassword({
+        userId: currentUser.id,
+        oldPassword,
+        newPassword,
+      });
+      setMessage('Şifre değiştirildi');
+      setOldPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : 'Hata oluştu');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Kullanıcı Ayarları</h1>
+
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-2">
+        {user ? (
+          <>
+            <div>
+              <span className="font-medium">Ad:</span> {user.firstName}
+            </div>
+            <div>
+              <span className="font-medium">Soyad:</span> {user.lastName}
+            </div>
+            <div>
+              <span className="font-medium">E-posta:</span> {user.email}
+            </div>
+          </>
+        ) : (
+          <p>Kullanıcı bilgileri yüklenemedi.</p>
+        )}
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <form className="space-y-4" onSubmit={handleChangePassword}>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Eski Şifre
+            </label>
+            <input
+              type="password"
+              value={oldPassword}
+              onChange={(e) => setOldPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Yeni Şifre
+            </label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Yeni Şifre (Onay)
+            </label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+          {message && <p className="text-sm text-red-600">{message}</p>}
+          <button
+            type="submit"
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
+          >
+            Şifreyi Güncelle
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,7 +2,7 @@ import { api } from './api';
 import { PageRequest, PaginatedResponse } from './templateService';
 
 export interface UserDto {
-  id: number;
+  id: string;
   email: string;
   firstName: string;
   lastName: string;
@@ -10,19 +10,19 @@ export interface UserDto {
 }
 
 export interface ChangePasswordDto {
-  userId: number;
+  userId: string;
   oldPassword: string;
   newPassword: string;
 }
 
 export const userService = {
-  getById: (id: number) => api.get<UserDto>(`/api/users/${id}`),
+  getById: (id: string) => api.get<UserDto>(`/api/users/${id}`),
   list: (page: PageRequest) =>
     api.get<PaginatedResponse<UserDto>>(`/api/users?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`),
   create: (data: Omit<UserDto, 'id'> & { password: string }) =>
     api.post<UserDto>('/api/users', data),
   update: (data: UserDto) => api.put<UserDto>('/api/users', data),
-  delete: (id: number) => api.delete<unknown>(`/api/users/${id}`),
+  delete: (id: string) => api.delete<unknown>(`/api/users/${id}`),
   changePassword: (data: ChangePasswordDto) =>
     api.put<unknown>('/api/users/change-password', data),
 };


### PR DESCRIPTION
## Summary
- decode user info from JWT with `userFromToken`
- initialize store with decoded info
- clean up stray prompt text in files
- **restore missing sidebar** by introducing `MainLayout`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ced5990c8325a7b750eda81611a9