### PR TITLE
Fix user list pagination query

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -17,8 +17,12 @@ export interface ChangePasswordDto {
 
 export const userService = {
   getById: (id: string) => api.get<UserDto>(`/api/users/${id}`),
-  list: (page: PageRequest) =>
-    api.get<PaginatedResponse<UserDto>>(`/api/users?pageNumber=${page.pageNumber}&pageSize=${page.pageSize}`),
+  list: (page?: PageRequest) =>
+    api.get<PaginatedResponse<UserDto>>(
+      page
+        ? `/api/users?pageNumber=${page.index}&pageSize=${page.size}`
+        : '/api/users'
+    ),
   create: (data: Omit<UserDto, 'id'> & { password: string }) =>
     api.post<UserDto>('/api/users', data),
   update: (data: UserDto) => api.put<UserDto>('/api/users', data),


### PR DESCRIPTION
## Summary
- handle optional pagination in `userService.list`
- use correct `index`/`size` fields when building query

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68711421e028832493d0d348189e2879