### PR TITLE
Fix page number query indexing

### DIFF
--- a/src/services/instantValueService.ts
+++ b/src/services/instantValueService.ts
@@ -15,7 +15,7 @@ export const instantValueService = {
     api.get<InstantValueDto>(`/api/instantvalues/${timestamp}`),
   list: (page: PageRequest, query?: DynamicQuery) =>
     api.post<PaginatedResponse<InstantValueDto>>(
-      `/api/instantvalues/list?pageNumber=${page.index}&pageSize=${page.size}`,
+      `/api/instantvalues/list?pageNumber=${page.index + 1}&pageSize=${page.size}`,
       query ?? {}
     ),
 };

--- a/src/services/operationClaimService.ts
+++ b/src/services/operationClaimService.ts
@@ -11,7 +11,7 @@ export const operationClaimService = {
     api.get<OperationClaimDto>(`/api/operationclaims/${id}`),
   list: (page: PageRequest) =>
     api.get<PaginatedResponse<OperationClaimDto>>(
-      `/api/operationclaims?PageNumber=${page.index}&PageSize=${page.size}`
+      `/api/operationclaims?PageNumber=${page.index + 1}&PageSize=${page.size}`
     ),
   create: (data: Omit<OperationClaimDto, 'id'>) =>
     api.post<OperationClaimDto>('/api/operationclaims', data),

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -17,7 +17,7 @@ export const tagService = {
   delete: (id: number) => api.delete<unknown>(`/api/reporttemplatetags/${id}`),
   list: (page: PageRequest, query?: DynamicQuery) =>
     api.post<PaginatedResponse<ReportTemplateTagDto>>(
-      `/api/reporttemplatetags/list?pageNumber=${page.index}&pageSize=${page.size}`,
+      `/api/reporttemplatetags/list?pageNumber=${page.index + 1}&pageSize=${page.size}`,
       query ?? {}
     ),
 };

--- a/src/services/userOperationClaimService.ts
+++ b/src/services/userOperationClaimService.ts
@@ -12,7 +12,7 @@ export const userOperationClaimService = {
     api.get<UserOperationClaimDto>(`/api/useroperationclaims/${id}`),
   list: (page: PageRequest) =>
     api.get<PaginatedResponse<UserOperationClaimDto>>(
-      `/api/useroperationclaims?PageNumber=${page.index}&PageSize=${page.size}`
+      `/api/useroperationclaims?PageNumber=${page.index + 1}&PageSize=${page.size}`
     ),
   create: (data: Omit<UserOperationClaimDto, 'id'>) =>
     api.post<UserOperationClaimDto>('/api/useroperationclaims', data),

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -20,7 +20,7 @@ export const userService = {
   list: (page?: PageRequest) =>
     api.get<PaginatedResponse<UserDto>>(
       page
-        ? `/api/users?pageNumber=${page.index}&pageSize=${page.size}`
+        ? `/api/users?pageNumber=${page.index + 1}&pageSize=${page.size}`
         : '/api/users'
     ),
   create: (data: Omit<UserDto, 'id'> & { password: string }) =>


### PR DESCRIPTION
## Summary
- ensure page numbers sent to the API start at 1

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687118ccf80c832486fac0778d0c18df