### PR TITLE
Add role counts to Yetkiler

### DIFF
--- a/src/components/OperationClaims/OperationClaimList.tsx
+++ b/src/components/OperationClaims/OperationClaimList.tsx
@@ -1,46 +1,70 @@
 import React, { useEffect, useState } from 'react';
-import { OperationClaimDto, operationClaimService } from '../../services';
+import { permissionController, RoleCounts } from '../../controllers/permissionController';
 
 export const OperationClaimList: React.FC = () => {
-  const [claims, setClaims] = useState<OperationClaimDto[]>([]);
+  const [counts, setCounts] = useState<RoleCounts | null>(null);
 
   useEffect(() => {
-    operationClaimService
-      .list({ index: 0, size: 50 })
-      .then((res) => setClaims(res.items))
-      .catch(() => setClaims([]));
+    permissionController
+      .getRoleCounts({ index: 0, size: 100 })
+      .then(res => setCounts(res))
+      .catch(() => setCounts(null));
   }, []);
+
+  const hasUsers = counts && counts.total > 0;
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-gray-900">Yetkiler</h1>
       </div>
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  İsim
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {claims.map((claim) => (
-                <tr key={claim.id} className="hover:bg-gray-50">
+      {hasUsers && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Rol
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Kullanıcı Sayısı
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                <tr>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">Admin</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {claim.name}
+                    {counts?.admin ?? 0}
                   </td>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+                <tr>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">Operator</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {counts?.operator ?? 0}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">Beklemede</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {counts?.pending ?? 0}
+                  </td>
+                </tr>
+                <tr className="font-semibold">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">Toplam Kullanıcılar</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {counts?.total ?? 0}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
-      {claims.length === 0 && (
+      )}
+      {(!hasUsers) && (
         <div className="text-center py-12">
-          <p className="text-gray-500">Hiç yetki bulunamadı.</p>
+          <p className="text-gray-500">Hiç kullanıcı bulunamadı.</p>
         </div>
       )}
     </div>

--- a/src/controllers/permissionController.ts
+++ b/src/controllers/permissionController.ts
@@ -1,0 +1,21 @@
+import { permissionService, PermissionUserDto } from '../services/permissionService';
+import { PageRequest } from '../services/templateService';
+
+export interface RoleCounts {
+  admin: number;
+  operator: number;
+  pending: number;
+  total: number;
+}
+
+export const permissionController = {
+  async getRoleCounts(page: PageRequest = { index: 0, size: 50 }): Promise<RoleCounts> {
+    const res = await permissionService.listUsers(page);
+    const users: PermissionUserDto[] = res.items || [];
+    const admin = users.filter(u => u.roleName.toLowerCase() === 'admin').length;
+    const operator = users.filter(u => u.roleName.toLowerCase() === 'operator').length;
+    const pending = users.filter(u => u.status === false).length;
+    const total = users.length;
+    return { admin, operator, pending, total };
+  },
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,3 +7,4 @@ export * from './dashboardService';
 export * from './operationClaimService';
 export * from './userOperationClaimService';
 export * from './instantValueService';
+export * from './permissionService';

--- a/src/services/permissionService.ts
+++ b/src/services/permissionService.ts
@@ -1,0 +1,17 @@
+import { api } from './api';
+import { PageRequest, PaginatedResponse } from './templateService';
+
+export interface PermissionUserDto {
+  id: string;
+  roleName: string;
+  status: boolean;
+}
+
+export const permissionService = {
+  listUsers: (page?: PageRequest) =>
+    api.get<PaginatedResponse<PermissionUserDto>>(
+      page
+        ? `/api/Users?pageNumber=${page.index + 1}&pageSize=${page.size}`
+        : '/api/Users'
+    ),
+};


### PR DESCRIPTION
## Summary
- get users from `/api/Users` via new `permissionService`
- compute counts in `permissionController`
- show Admin/Operator/Beklemede counts in Yetkiler page

## Testing
- `npm run lint` *(fails: cannot resolve @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68775ca6802c8325b32b6dd38620c86d