### PR TITLE
Add template edit page with toast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { LoginForm } from './components/Auth/LoginForm';
 import { Header } from './components/Layout/Header';
 import { Sidebar } from './components/Layout/Sidebar';
 import { Dashboard } from './components/Dashboard/Dashboard';
 import { TemplateList } from './components/Templates/TemplateList';
+import { TemplateEditForm } from './components/Templates/TemplateEditForm';
 import { TagList } from './components/Tags/TagList';
 import { SimpleUserList } from './components/Users/SimpleUserList';
 import { LogList } from './components/Logs/LogList';
@@ -17,6 +18,18 @@ import { authStore } from './store/authStore';
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(authStore.getIsAuthenticated());
   const [activeTab, setActiveTab] = useState('dashboard');
+  const [route, setRoute] = useState(window.location.pathname);
+
+  useEffect(() => {
+    const handler = () => setRoute(window.location.pathname);
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  const navigate = (path: string) => {
+    window.history.pushState({}, '', path);
+    setRoute(path);
+  };
 
   const handleLogin = () => {
     setIsAuthenticated(true);
@@ -57,6 +70,23 @@ function App() {
 
   if (!isAuthenticated) {
     return <LoginForm onLogin={handleLogin} />;
+  }
+
+  if (route.startsWith('/Templates/Edit/')) {
+    const id = parseInt(route.split('/').pop() || '0', 10);
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Header onLogout={handleLogout} onOpenUserSettings={() => setActiveTab('user-settings')} />
+        <div className="flex">
+          <Sidebar activeTab="templates" onTabChange={(tab) => { setActiveTab(tab); navigate('/'); }} />
+          <main className="flex-1 p-6">
+            <div className="max-w-7xl mx-auto">
+              <TemplateEditForm id={id} onSuccess={() => navigate('/Templates')} onCancel={() => navigate('/Templates')} />
+            </div>
+          </main>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/SimpleToast.tsx
+++ b/src/components/SimpleToast.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+
+interface SimpleToastProps {
+  message: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const SimpleToast: React.FC<SimpleToastProps> = ({ message, open, onClose }) => {
+  useEffect(() => {
+    if (open) {
+      const t = setTimeout(onClose, 3000);
+      return () => clearTimeout(t);
+    }
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed top-4 inset-x-0 flex justify-center z-50">
+      <div className="bg-green-100 text-green-800 border border-green-300 rounded-lg px-4 py-2 flex items-start space-x-2">
+        <span className="flex-1 text-sm">{message}</span>
+        <button onClick={onClose} className="text-green-800">×</button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Templates/TemplateEditForm.tsx
+++ b/src/components/Templates/TemplateEditForm.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { templateService } from '../../services';
+import { SimpleToast } from '../SimpleToast';
+
+interface TemplateEditFormProps {
+  id: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSuccess, onCancel }) => {
+  const [name, setName] = useState('');
+  const [opcEndpoint, setOpcEndpoint] = useState('');
+  const [pullInterval, setPullInterval] = useState(0);
+  const [isActive, setIsActive] = useState(true);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+
+  useEffect(() => {
+    templateService.getById(id).then((res) => {
+      setName(res.name);
+      setOpcEndpoint(res.opcEndpoint);
+      setPullInterval(res.pullInterval);
+      setIsActive(!!res.isActive);
+    });
+  }, [id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+    try {
+      await templateService.update({ id, name, opcEndpoint, pullInterval, isActive });
+      setShowToast(true);
+      setTimeout(() => {
+        setShowToast(false);
+        onSuccess();
+      }, 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Hata oluştu');
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Şablonu Düzenle</h1>
+      <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">İsim</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">OPC Endpoint</label>
+          <input
+            type="text"
+            value={opcEndpoint}
+            onChange={(e) => setOpcEndpoint(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Çekme Aralığı (s)</label>
+          <input
+            type="number"
+            value={pullInterval}
+            onChange={(e) => setPullInterval(Number(e.target.value))}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <input
+            id="isActive"
+            type="checkbox"
+            checked={isActive}
+            onChange={(e) => setIsActive(e.target.checked)}
+            className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+          />
+          <label htmlFor="isActive" className="text-sm font-medium text-gray-700">Aktif</label>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div className="flex space-x-2 pt-2">
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            Kaydet
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300 transition-colors"
+          >
+            İptal
+          </button>
+        </div>
+      </form>
+      <SimpleToast message="Şablon başarıyla güncellendi." open={showToast} onClose={() => { setShowToast(false); onSuccess(); }} />
+    </div>
+  );
+};

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -67,6 +67,11 @@ export const TemplateList: React.FC = () => {
     setDeleteId(null);
   };
 
+  const handleEdit = (id: number) => {
+    window.history.pushState({}, '', `/Templates/Edit/${id}`);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
   if (showCreateForm) {
     return (
       <TemplateCreateForm
@@ -136,7 +141,10 @@ export const TemplateList: React.FC = () => {
                 >
                   <Power className="h-4 w-4" />
                 </button>
-                <button className="p-2 rounded-md text-gray-600 hover:bg-gray-50">
+                <button
+                  onClick={() => handleEdit(template.id)}
+                  className="p-2 rounded-md text-gray-600 hover:bg-gray-50"
+                >
                   <Edit2 className="h-4 w-4" />
                 </button>
                 <button 


### PR DESCRIPTION
## Summary
- allow editing templates from TemplateList
- provide toast notifications
- add TemplateEditForm component and simple toast
- navigate using history API when editing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877951d87348325bb0309256625768e