### PR TITLE
Fix role display and enable user creation with claims

### DIFF
--- a/src/components/OperationClaims/OperationClaimList.tsx
+++ b/src/components/OperationClaims/OperationClaimList.tsx
@@ -21,9 +21,9 @@ export const OperationClaimList: React.FC = () => {
           userService.list({ index: 0, size: 100 }),
         ]);
         setClaims(claimRes.items);
-        const userMap: Record<number, UserDto> = {};
+        const userMap: Record<string, UserDto> = {};
         userRes.items.forEach((u) => {
-          userMap[Number(u.id)] = u;
+          userMap[u.id] = u;
         });
         const grouped: Record<number, UserDto[]> = {};
         userClaimRes.items.forEach((uc) => {

--- a/src/components/UserOperationClaims/UserOperationClaimList.tsx
+++ b/src/components/UserOperationClaims/UserOperationClaimList.tsx
@@ -10,7 +10,7 @@ import {
 
 export const UserOperationClaimList: React.FC = () => {
   const [claims, setClaims] = useState<UserOperationClaimDto[]>([]);
-  const [users, setUsers] = useState<Record<number, UserDto>>({});
+  const [users, setUsers] = useState<Record<string, UserDto>>({});
   const [ops, setOps] = useState<Record<number, OperationClaimDto>>({});
 
   useEffect(() => {
@@ -22,9 +22,9 @@ export const UserOperationClaimList: React.FC = () => {
           operationClaimService.list({ index: 0, size: 100 }),
         ]);
         setClaims(claimRes.items);
-        const uMap: Record<number, UserDto> = {};
+        const uMap: Record<string, UserDto> = {};
         userRes.items.forEach((u) => {
-          uMap[Number(u.id)] = u;
+          uMap[u.id] = u;
         });
         setUsers(uMap);
         const oMap: Record<number, OperationClaimDto> = {};

--- a/src/components/Users/UserCreateForm.tsx
+++ b/src/components/Users/UserCreateForm.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import {
+  userService,
+  operationClaimService,
+  OperationClaimDto,
+} from '../../services';
+
+interface UserCreateFormProps {
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export const UserCreateForm: React.FC<UserCreateFormProps> = ({
+  onSuccess,
+  onCancel,
+}) => {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [operationClaimId, setOperationClaimId] = useState(0);
+  const [claims, setClaims] = useState<OperationClaimDto[]>([]);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    operationClaimService
+      .list({ index: 0, size: 100 })
+      .then(res => setClaims(res.items))
+      .catch(() => setClaims([]));
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+    try {
+      await userService.create({
+        email,
+        firstName,
+        lastName,
+        password,
+        operationClaimId,
+      });
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Hata oluştu');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Yeni Kullanıcı</h1>
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4"
+      >
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Ad</label>
+          <input
+            type="text"
+            value={firstName}
+            onChange={e => setFirstName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Soyad</label>
+          <input
+            type="text"
+            value={lastName}
+            onChange={e => setLastName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">E-posta</label>
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Şifre</label>
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Rol</label>
+          <select
+            value={operationClaimId}
+            onChange={e => setOperationClaimId(Number(e.target.value))}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value={0}>Varsayılan</option>
+            {claims.map(c => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div className="flex space-x-2 pt-2">
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            Kaydet
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300 transition-colors"
+          >
+            İptal
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+

--- a/src/components/Users/UserList.tsx
+++ b/src/components/Users/UserList.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { Plus, Search, UserCheck, UserX, Edit2, RefreshCcw } from 'lucide-react';
 import { User } from '../../types';
 import { userService } from '../../services';
+import { UserCreateForm } from './UserCreateForm';
 
 export const UserList: React.FC = () => {
   const [users, setUsers] = useState<User[]>([]);
+  const [showCreateForm, setShowCreateForm] = useState(false);
 
   const loadData = () => {
     userService
@@ -15,7 +17,7 @@ export const UserList: React.FC = () => {
             id: u.id.toString(),
             username: `${u.firstName} ${u.lastName}`,
             email: u.email,
-            role: 'operator',
+            role: (u.operationClaimName?.toLowerCase() as User['role']) || 'operator',
             createdAt: new Date().toISOString(),
             isActive: u.status ?? true,
           }))
@@ -77,6 +79,18 @@ export const UserList: React.FC = () => {
     }
   };
 
+  if (showCreateForm) {
+    return (
+      <UserCreateForm
+        onSuccess={() => {
+          setShowCreateForm(false);
+          loadData();
+        }}
+        onCancel={() => setShowCreateForm(false)}
+      />
+    );
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -89,7 +103,10 @@ export const UserList: React.FC = () => {
             <RefreshCcw className="h-4 w-4" />
             <span>Yenile</span>
           </button>
-          <button className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 flex items-center space-x-2 transition-colors">
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 flex items-center space-x-2 transition-colors"
+          >
             <Plus className="h-5 w-5" />
             <span>Yeni Kullanıcı</span>
           </button>

--- a/src/components/Users/UserSettings.tsx
+++ b/src/components/Users/UserSettings.tsx
@@ -85,7 +85,7 @@ export const UserSettings: React.FC = () => {
       setUser({ id: currentUser.id, email, firstName, lastName });
       setToastMessage('Bilgiler güncellendi');
       setShowToast(true);
-    } catch (err) {
+    } catch {
       // ignore error for now
     } finally {
       setSavingInfo(false);

--- a/src/services/userOperationClaimService.ts
+++ b/src/services/userOperationClaimService.ts
@@ -3,7 +3,7 @@ import { PageRequest, PaginatedResponse } from './templateService';
 
 export interface UserOperationClaimDto {
   id: number;
-  userId: number;
+  userId: string;
   operationClaimId: number;
 }
 
@@ -20,3 +20,4 @@ export const userOperationClaimService = {
     api.put<UserOperationClaimDto>('/api/useroperationclaims', data),
   delete: (id: number) => api.delete<unknown>(`/api/useroperationclaims/${id}`),
 };
+

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -7,6 +7,8 @@ export interface UserDto {
   firstName: string;
   lastName: string;
   status?: boolean;
+  operationClaimId?: number;
+  operationClaimName?: string;
 }
 
 export interface ChangePasswordDto {
@@ -23,8 +25,9 @@ export const userService = {
         ? `/api/users?pageNumber=${page.index + 1}&pageSize=${page.size}`
         : '/api/users'
     ),
-  create: (data: Omit<UserDto, 'id'> & { password: string }) =>
-    api.post<UserDto>('/api/users', data),
+  create: (
+    data: Omit<UserDto, 'id' | 'operationClaimName'> & { password: string }
+  ) => api.post<UserDto>('/api/users', data),
   update: (data: UserDto) => api.put<UserDto>('/api/users', data),
   delete: (id: string) => api.delete<unknown>(`/api/users/${id}`),
   changePassword: (data: ChangePasswordDto) =>


### PR DESCRIPTION
## Summary
- include role info in `UserDto`
- map user IDs as strings when aggregating claims
- show correct role names in user list
- allow admins to create new users with an optional role
- fix lint error in user settings

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68779eb5bf8483248858dadcf9b48842