### PR TITLE
Add OPC UA service functions

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,3 +7,4 @@ export * from './dashboardService';
 export * from './operationClaimService';
 export * from './userOperationClaimService';
 export * from './instantValueService';
+export * from './opcService';

--- a/src/services/opcService.ts
+++ b/src/services/opcService.ts
@@ -1,0 +1,44 @@
+import { api } from './api';
+
+export interface ApiResponse<T> {
+  success: boolean;
+  serverStatus: string;
+  timestamp: string;
+  message: string;
+  data: T;
+}
+
+export interface OpcReadResult {
+  nodeId: string;
+  value: string;
+  nodeStatus: string;
+}
+
+export interface BrowseItem {
+  displayName: string;
+  nodeId: string;
+  nodeClass: string;
+}
+
+export interface TreeNode {
+  displayName: string;
+  nodeId: string;
+  nodeClass: string;
+  children: string[];
+}
+
+export const opcService = {
+  connect: (endpoint: string) =>
+    api.post<ApiResponse<string>>('/Opc/Connect', endpoint),
+  read: (nodeId: string) =>
+    api.get<ApiResponse<OpcReadResult>>(`/Opc/read?nodeId=${encodeURIComponent(nodeId)}`),
+  write: (nodeId: string, value: string) =>
+    api.post<ApiResponse<string>>('/Opc/Write', { nodeId, value }),
+  browse: (nodeId: string) =>
+    api.get<ApiResponse<BrowseItem[]>>(`/Opc/Browse?nodeId=${encodeURIComponent(nodeId)}`),
+  tree: (nodeId: string) =>
+    api.get<ApiResponse<TreeNode>>(`/Opc/tree?nodeId=${encodeURIComponent(nodeId)}`),
+  discover: (networkPrefix: string, port: number) =>
+    api.get<ApiResponse<string[]>>(`/Discover?networkPrefix=${encodeURIComponent(networkPrefix)}&port=${port}`),
+  disconnect: () => api.post<ApiResponse<unknown>>('/Opc/disconnect'),
+};


### PR DESCRIPTION
## Summary
- create `opcService` for OPC UA API endpoints
- export opcService in services index

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878dc3a74fc8324a63a6312b2af68b5