### PR TITLE
Position role select popup beside button

### DIFF
--- a/src/components/RoleSelectToast.tsx
+++ b/src/components/RoleSelectToast.tsx
@@ -5,6 +5,7 @@ interface RoleSelectToastProps {
   open: boolean;
   claims: OperationClaimDto[];
   defaultClaimId?: number;
+  anchor?: { top: number; left: number };
   onConfirm: (claimId: number) => void;
   onCancel: () => void;
 }
@@ -13,6 +14,7 @@ export const RoleSelectToast: React.FC<RoleSelectToastProps> = ({
   open,
   claims,
   defaultClaimId,
+  anchor,
   onConfirm,
   onCancel,
 }) => {
@@ -24,9 +26,17 @@ export const RoleSelectToast: React.FC<RoleSelectToastProps> = ({
 
   if (!open) return null;
 
+  const containerClass = anchor
+    ? 'fixed z-50'
+    : 'fixed top-4 inset-x-0 flex justify-center z-50';
+  const containerStyle = anchor ? { top: anchor.top, left: anchor.left } : {};
+  const innerClass = `bg-white border border-gray-200 rounded-lg shadow-lg p-4 flex items-center space-x-2${
+    anchor ? ' transform -translate-x-full mr-2' : ''
+  }`;
+
   return (
-    <div className="fixed top-4 inset-x-0 flex justify-center z-50">
-      <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-4 flex items-center space-x-2">
+    <div className={containerClass} style={containerStyle}>
+      <div className={innerClass}>
         <select
           value={claimId}
           onChange={(e) => setClaimId(Number(e.target.value))}

--- a/src/components/UserOperationClaims/UserOperationClaimList.tsx
+++ b/src/components/UserOperationClaims/UserOperationClaimList.tsx
@@ -48,14 +48,20 @@ export const UserOperationClaimList: React.FC = () => {
   );
   const [availableClaims, setAvailableClaims] = useState<OperationClaimDto[]>([]);
   const [showDialog, setShowDialog] = useState(false);
+  const [dialogPos, setDialogPos] = useState<{ top: number; left: number }>();
   const [toastMessage, setToastMessage] = useState('');
   const [showToast, setShowToast] = useState(false);
 
-  const openDialog = async (claim: UserOperationClaimDto) => {
+  const openDialog = async (
+    claim: UserOperationClaimDto,
+    e: React.MouseEvent<HTMLButtonElement>
+  ) => {
     try {
       const res = await operationClaimService.list({ index: 0, size: 10 });
       setAvailableClaims(res.items);
       setDialogClaim(claim);
+      const rect = e.currentTarget.getBoundingClientRect();
+      setDialogPos({ top: rect.top, left: rect.left });
       setShowDialog(true);
     } catch {
       setAvailableClaims([]);
@@ -82,6 +88,7 @@ export const UserOperationClaimList: React.FC = () => {
     } finally {
       setShowDialog(false);
       setDialogClaim(null);
+      setDialogPos(undefined);
     }
   };
 
@@ -114,7 +121,7 @@ export const UserOperationClaimList: React.FC = () => {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                       <button
-                        onClick={() => openDialog(claim)}
+                        onClick={(e) => openDialog(claim, e)}
                         className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
                       >
                         {name.toLowerCase() === 'beklemede' ? 'Yetki Ver' : 'Yetki Değiştir'}
@@ -147,8 +154,12 @@ export const UserOperationClaimList: React.FC = () => {
         open={showDialog}
         claims={availableClaims}
         defaultClaimId={dialogClaim?.operationClaimId}
+        anchor={dialogPos}
         onConfirm={handleChangeClaim}
-        onCancel={() => setShowDialog(false)}
+        onCancel={() => {
+          setShowDialog(false);
+          setDialogPos(undefined);
+        }}
       />
       <SimpleToast
         message={toastMessage}


### PR DESCRIPTION
## Summary
- add anchor positioning support for `RoleSelectToast`
- open role selection popup to the left of the clicked button

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6878eddab2f88325a8241aab554bdbfd