### PR TITLE
Remove mock login and wire settings to backend

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,23 +1,38 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Save, Database, Globe, Bell, Shield } from 'lucide-react';
+import { SystemSettings } from '../../types';
+import { systemSettingsService } from '../../services';
 
 export const Settings: React.FC = () => {
-  const [settings, setSettings] = useState({
-    opcServerUrl: 'opc.tcp://192.168.1.100:4840',
-    dbConnectionString: 'postgresql://user:pass@localhost:5432/iskisars',
-    dataRetentionDays: 90,
+  const [settings, setSettings] = useState<SystemSettings>({
+    opcServerUrl: '',
+    databaseConnection: '',
+    retentionDays: 0,
     emailNotifications: true,
-    smsNotifications: false,
-    alertThreshold: 85,
+    smsNotifications: true,
+    alertThreshold: 0,
+    sessionTimeout: 0,
+    logLevel: 0,
     backupEnabled: true,
-    backupInterval: 24,
-    logLevel: 'info',
-    sessionTimeout: 30
+    backupIntervalHours: 0,
   });
 
+  useEffect(() => {
+    systemSettingsService
+      .get()
+      .then((data) => setSettings(data))
+      .catch(() => {
+        /* handle error */
+      });
+  }, []);
+
   const handleSave = () => {
-    // Save settings logic here
-    alert('Ayarlar kaydedildi!');
+    systemSettingsService
+      .save(settings)
+      .then(() => alert('Ayarlar kaydedildi!'))
+      .catch(() => {
+        /* handle error */
+      });
   };
 
   return (
@@ -60,8 +75,8 @@ export const Settings: React.FC = () => {
               </label>
               <input
                 type="text"
-                value={settings.dbConnectionString}
-                onChange={(e) => setSettings({...settings, dbConnectionString: e.target.value})}
+                value={settings.databaseConnection}
+                onChange={(e) => setSettings({...settings, databaseConnection: e.target.value})}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
             </div>
@@ -72,8 +87,8 @@ export const Settings: React.FC = () => {
               </label>
               <input
                 type="number"
-                value={settings.dataRetentionDays}
-                onChange={(e) => setSettings({...settings, dataRetentionDays: Number(e.target.value)})}
+                value={settings.retentionDays}
+                onChange={(e) => setSettings({...settings, retentionDays: Number(e.target.value)})}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
             </div>
@@ -152,13 +167,13 @@ export const Settings: React.FC = () => {
               </label>
               <select
                 value={settings.logLevel}
-                onChange={(e) => setSettings({...settings, logLevel: e.target.value})}
+                onChange={(e) => setSettings({...settings, logLevel: Number(e.target.value)})}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="error">Error</option>
-                <option value="warn">Warning</option>
-                <option value="info">Info</option>
-                <option value="debug">Debug</option>
+                <option value={0}>Error</option>
+                <option value={1}>Warning</option>
+                <option value={2}>Info</option>
+                <option value={3}>Debug</option>
               </select>
             </div>
           </div>
@@ -190,8 +205,8 @@ export const Settings: React.FC = () => {
               </label>
               <input
                 type="number"
-                value={settings.backupInterval}
-                onChange={(e) => setSettings({...settings, backupInterval: Number(e.target.value)})}
+                value={settings.backupIntervalHours}
+                onChange={(e) => setSettings({...settings, backupIntervalHours: Number(e.target.value)})}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 disabled={!settings.backupEnabled}
               />

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,4 @@ export * from './operationClaimService';
 export * from './userOperationClaimService';
 export * from './instantValueService';
 export * from './opcService';
+export * from './systemSettingsService';

--- a/src/services/systemSettingsService.ts
+++ b/src/services/systemSettingsService.ts
@@ -1,0 +1,7 @@
+import { api } from './api';
+import { SystemSettings } from '../types';
+
+export const systemSettingsService = {
+  get: () => api.get<SystemSettings>('/api/SystemSettings'),
+  save: (settings: SystemSettings) => api.post<unknown>('/api/SystemSettings', settings),
+};

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -73,35 +73,19 @@ class AuthStore {
   }
 
   async login(email: string, password: string): Promise<User> {
-    try {
-      const token = await authService.login({ email, password });
-      this.user =
-        payloadToUser(parseJwt(token.token), email) || {
-          id: '',
-          username: email,
-          email,
-          role: 'operator',
-          createdAt: '',
-          isActive: true,
-        };
-      this.isAuthenticated = true;
-      this.setSession(token);
-      return this.user;
-    } catch (err) {
-      // If backend is unreachable, allow mock admin login
-      if (email === 'admin@gmail.com' && password === '123') {
-        const mockToken: AccessToken = {
-          token: 'mock-token',
-          refreshToken: 'mock-refresh',
-          expiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-        };
-        this.user = { id: '1', username: 'admin', email, role: 'admin', createdAt: '', isActive: true };
-        this.isAuthenticated = true;
-        this.setSession(mockToken);
-        return this.user;
-      }
-      throw err;
-    }
+    const token = await authService.login({ email, password });
+    this.user =
+      payloadToUser(parseJwt(token.token), email) || {
+        id: '',
+        username: email,
+        email,
+        role: 'operator',
+        createdAt: '',
+        isActive: true,
+      };
+    this.isAuthenticated = true;
+    this.setSession(token);
+    return this.user;
   }
 
   private setSession(token: AccessToken) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,3 +68,16 @@ export interface DashboardStats {
   alerts24h: number;
   uptime: string;
 }
+
+export interface SystemSettings {
+  opcServerUrl: string;
+  databaseConnection: string;
+  retentionDays: number;
+  emailNotifications: boolean;
+  smsNotifications: boolean;
+  alertThreshold: number;
+  sessionTimeout: number;
+  logLevel: number;
+  backupEnabled: boolean;
+  backupIntervalHours: number;
+}


### PR DESCRIPTION
## Summary
- remove fallback mock login logic
- define `SystemSettings` type
- create service for system settings
- wire `Settings` page to fetch and post via new service

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878ef8d54fc832496701a1c3ebadcff