### PR TITLE
Remove non-clickable menu header

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -38,10 +38,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeTab, onTabChange }) => {
   return (
     <div className="w-64 bg-gray-800 min-h-screen">
       <div className="p-4">
-        <div className="flex items-center space-x-2 mb-8">
-          <Activity className="h-6 w-6 text-blue-400" />
-          <span className="text-white font-semibold">Sistem Durumu</span>
-        </div>
+        <div className="mb-8" />
         
         <nav className="space-y-2">
           {filteredItems.map((item) => {


### PR DESCRIPTION
## Summary
- remove the non-interactive `Sistem Durumu` header from the sidebar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878f74f0a008325991194e55ea8ac82