### PR TITLE
Fix OPC connection reuse

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -5,7 +5,6 @@ import {
   Tags,
   Users,
   Settings,
-  Activity,
   Shield,
   Key,
   UserCog

--- a/src/components/Templates/TemplateTagManager.tsx
+++ b/src/components/Templates/TemplateTagManager.tsx
@@ -52,13 +52,20 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
   const fetchTree = async () => {
     setLoadingTree(true);
     try {
-      if (opcEndpoint) {
-        await opcService.connect(opcEndpoint);
-      }
       const res = await opcService.tree('');
       setTree(res.data);
     } catch {
-      setTree(null);
+      try {
+        if (opcEndpoint) {
+          await opcService.connect(opcEndpoint);
+          const res = await opcService.tree('');
+          setTree(res.data);
+        } else {
+          setTree(null);
+        }
+      } catch {
+        setTree(null);
+      }
     } finally {
       setLoadingTree(false);
     }


### PR DESCRIPTION
## Summary
- reconnect to OPC UA endpoint only when needed
- cleanup unused Activity icon to satisfy ESLint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878fa3fa7e48324ab03632abfbdacfc