### PR TITLE
Fix sidebar padding

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -36,7 +36,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeTab, onTabChange }) => {
 
   return (
     <div className="w-64 bg-gray-800 min-h-screen">
-      <div className="p-4 pt-2">
+      <div className="p-4">
         
         <nav className="space-y-2">
           {filteredItems.map((item) => {


### PR DESCRIPTION
## Summary
- ensure the sidebar menu top padding matches its horizontal padding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878fd9e9dd48325b137aaf507ca54b7