### PR TITLE
Integrate backend log service

### DIFF
--- a/src/components/Logs/LogList.tsx
+++ b/src/components/Logs/LogList.tsx
@@ -1,7 +1,55 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { logService } from '../../services';
+import { LogDto, LogLevel } from '../../types';
 
-export const LogList: React.FC = () => (
-  <div className="text-center py-12">
-    <p className="text-gray-500">Log bileşeni henüz uygulanmadı.</p>
-  </div>
-);
+export const LogList: React.FC = () => {
+  const [logs, setLogs] = useState<LogDto[]>([]);
+
+  useEffect(() => {
+    logService
+      .list({ index: 0, size: 50 })
+      .then((res) => setLogs(res.items))
+      .catch(() => setLogs([]));
+  }, []);
+
+  const levelToString = (level: LogLevel) => LogLevel[level];
+
+  return (
+    <div className="space-y-6 px-2">
+      <h1 className="text-2xl font-semibold text-gray-900">Loglar</h1>
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Seviye</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Mesaj</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tarih</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {logs.map((log) => (
+                <tr key={log.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {levelToString(log.level)}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {log.message}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {new Date(log.createdAt).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {logs.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-gray-500">Hiç log bulunamadı.</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,3 +9,4 @@ export * from './userOperationClaimService';
 export * from './instantValueService';
 export * from './opcService';
 export * from './systemSettingsService';
+export * from './logService';

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,0 +1,12 @@
+import { api } from './api';
+import { PageRequest, PaginatedResponse } from './templateService';
+import { LogDto, CreateLogDto } from '../types';
+
+export const logService = {
+  getById: (id: number) => api.get<LogDto>(`/api/Logs/${id}`),
+  create: (data: CreateLogDto) => api.post<LogDto>('/api/Logs', data),
+  list: (page: PageRequest) =>
+    api.get<PaginatedResponse<LogDto>>(
+      `/api/Logs?PageNumber=${page.index + 1}&PageSize=${page.size}`
+    ),
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,29 @@ export interface SystemMetric {
   lastUpdated: string;
 }
 
+export enum LogLevel {
+  Trace = 0,
+  Debug = 1,
+  Info = 2,
+  Warn = 3,
+  Error = 4,
+  Fatal = 5,
+}
+
+export interface LogDto {
+  id: number;
+  level: LogLevel;
+  message: string;
+  detail: string;
+  createdAt: string;
+}
+
+export interface CreateLogDto {
+  level: LogLevel;
+  message: string;
+  detail: string;
+}
+
 export interface LogEntry {
   id: string;
   userId: string;


### PR DESCRIPTION
## Summary
- define LogLevel enum and DTOs
- implement log service
- show logs in a table view
- export new service

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879f7d2a07883248a58369b587d6403