### PR TITLE
Update dashboard status handling

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -19,6 +19,19 @@ export const Dashboard: React.FC = () => {
   const [stats, setStats] = useState<DashboardStats>(dataStore.getDashboardStats());
   const [systemMetrics, setSystemMetrics] = useState<SystemMetric[]>(dataStore.getSystemMetrics());
 
+  const normalizeStatus = (status: string) => {
+    const s = status.toLowerCase();
+    if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
+    if (['warning', 'degraded'].includes(s)) return 'warning';
+    return 'good';
+  };
+
+  const overallSystemHealth = React.useMemo(() => {
+    if (systemMetrics.some(m => normalizeStatus(m.status) === 'bad')) return 'bad';
+    if (systemMetrics.some(m => normalizeStatus(m.status) === 'warning')) return 'warning';
+    return 'good';
+  }, [systemMetrics]);
+
   useEffect(() => {
     dashboardService
       .stats()
@@ -90,9 +103,21 @@ export const Dashboard: React.FC = () => {
         />
         <DashboardCard
           title="Sistem Durumu"
-          value={stats.systemHealth === 'healthy' ? 'Sağlıklı' : 'Uyarı'}
+          value={
+            overallSystemHealth === 'good'
+              ? 'Sağlıklı'
+              : overallSystemHealth === 'warning'
+                ? 'Uyarı'
+                : 'Sağlıksız'
+          }
           icon={Server}
-          color={stats.systemHealth === 'healthy' ? 'green' : 'yellow'}
+          color={
+            overallSystemHealth === 'good'
+              ? 'green'
+              : overallSystemHealth === 'warning'
+                ? 'yellow'
+                : 'red'
+          }
         />
       </div>
     </div>

--- a/src/components/Dashboard/SystemStatus.tsx
+++ b/src/components/Dashboard/SystemStatus.tsx
@@ -9,20 +9,19 @@ interface SystemStatusProps {
 export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
   const normalizeStatus = (status: string) => {
     const s = status.toLowerCase();
-    if (['connected', 'ok', 'healthy', 'running'].includes(s)) return 'healthy';
+    if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
     if (['warning', 'degraded'].includes(s)) return 'warning';
-    if (['disconnected', 'critical', 'error', 'failed'].includes(s)) return 'critical';
-    return 'unknown';
+    return 'good';
   };
 
   const getStatusIcon = (status: string) => {
     const normalized = normalizeStatus(status);
     switch (normalized) {
-      case 'healthy':
+      case 'good':
         return <CheckCircle className="h-5 w-5 text-green-500" />;
       case 'warning':
         return <AlertCircle className="h-5 w-5 text-yellow-500" />;
-      case 'critical':
+      case 'bad':
         return <XCircle className="h-5 w-5 text-red-500" />;
       default:
         return <AlertCircle className="h-5 w-5 text-gray-500" />;
@@ -32,11 +31,11 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
   const getStatusColor = (status: string) => {
     const normalized = normalizeStatus(status);
     switch (normalized) {
-      case 'healthy':
+      case 'good':
         return 'bg-green-50 border-green-200';
       case 'warning':
         return 'bg-yellow-50 border-yellow-200';
-      case 'critical':
+      case 'bad':
         return 'bg-red-50 border-red-200';
       default:
         return 'bg-gray-50 border-gray-200';
@@ -46,11 +45,11 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
   const getStatusTextColor = (status: string) => {
     const normalized = normalizeStatus(status);
     switch (normalized) {
-      case 'healthy':
+      case 'good':
         return 'text-green-600';
       case 'warning':
         return 'text-yellow-600';
-      case 'critical':
+      case 'bad':
         return 'text-red-600';
       default:
         return 'text-gray-600';


### PR DESCRIPTION
## Summary
- adjust metric status evaluation logic
- compute overall system health from metrics
- update the "Sistem Durumu" card to show health, warning, or bad status colors

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a08b7b0bc8324b020fa1f278f6c69