### PR TITLE
Fix dashboard chart grouping

### DIFF
--- a/src/components/Dashboard/DataChart.tsx
+++ b/src/components/Dashboard/DataChart.tsx
@@ -18,10 +18,13 @@ export const DataChart: React.FC = () => {
     const now = new Date();
     const start = new Date(now);
     start.setHours(start.getHours() - 24, 0, 0, 0);
+    const end = new Date(now);
+    end.setMinutes(59, 59, 999);
 
     const query: DynamicQuery = {
       filters: [
         { field: 'timestamp', operator: 'gte', value: start.toISOString() },
+        { field: 'timestamp', operator: 'lte', value: end.toISOString() },
       ],
       sorts: [{ field: 'timestamp', direction: 'asc' }],
     };
@@ -83,7 +86,9 @@ export const DataChart: React.FC = () => {
           
           {/* Chart line */}
           <polyline
-            points={data.map((d, i) => `${(i * 66.67)},${200 - (d.value / maxValue) * 160}`).join(' ')}
+            points={data
+              .map((d, i) => `${(i * (400 / Math.max(data.length - 1, 1)))},${200 - (d.value / maxValue) * 160}`)
+              .join(' ')}
             fill="none"
             stroke="#3b82f6"
             strokeWidth="2"
@@ -93,7 +98,7 @@ export const DataChart: React.FC = () => {
           {data.map((d, i) => (
             <circle
               key={d.time}
-              cx={i * 66.67}
+              cx={i * (400 / Math.max(data.length - 1, 1))}
               cy={200 - (d.value / maxValue) * 160}
               r="4"
               fill="#3b82f6"

--- a/src/components/Dashboard/SystemStatus.tsx
+++ b/src/components/Dashboard/SystemStatus.tsx
@@ -68,8 +68,11 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
       <h3 className="text-lg font-semibold text-gray-900 mb-4">Sistem Durumu</h3>
       
       <div className="space-y-4">
-        {metrics.map((metric) => (
-          <div key={metric.id} className={`p-4 rounded-lg border ${getStatusColor(metric.status)}`}>
+        {metrics.map((metric, idx) => (
+          <div
+            key={metric.id ?? idx}
+            className={`p-4 rounded-lg border ${getStatusColor(metric.status)}`}
+          >
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
                 {getStatusIcon(metric.status)}


### PR DESCRIPTION
## Summary
- improve instant values query with start/end filters
- draw chart with dynamic point spacing
- ensure unique keys for system metrics list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a117b446c8324a7d0b89095337688