### PR TITLE
Swap tag tree and list

### DIFF
--- a/src/components/Templates/TemplateTagManager.tsx
+++ b/src/components/Templates/TemplateTagManager.tsx
@@ -170,6 +170,34 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 px-2">
         <div>
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden h-[calc(100vh-12rem)] flex flex-col">
+            <div className="flex justify-end p-4 border-b space-x-2">
+              <button
+                onClick={fetchTree}
+                className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
+              >
+                Opc Taglarını Getir
+              </button>
+              <button
+                onClick={saveTags}
+                disabled={Object.keys(selected).length === 0}
+                className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
+              >
+                Kaydet
+              </button>
+            </div>
+            <div className="flex-1 p-4 overflow-auto">
+              {loadingTree && (
+                <p className="text-center text-sm text-gray-500">Yükleniyor...</p>
+              )}
+              {!loadingTree && tree && (
+                <ul className="text-sm">{renderTree(tree)}</ul>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden h-[calc(100vh-12rem)] flex flex-col">
             <div className="flex-1 overflow-auto">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
@@ -211,34 +239,6 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
               <p className="text-gray-500">Hiç etiket bulunamadı.</p>
             </div>
           )}
-        </div>
-
-        <div>
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden h-[calc(100vh-12rem)] flex flex-col">
-            <div className="flex justify-end p-4 border-b space-x-2">
-              <button
-                onClick={fetchTree}
-                className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
-              >
-                Opc Taglarını Getir
-              </button>
-              <button
-                onClick={saveTags}
-                disabled={Object.keys(selected).length === 0}
-                className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
-              >
-                Kaydet
-              </button>
-            </div>
-            <div className="flex-1 p-4 overflow-auto">
-              {loadingTree && (
-                <p className="text-center text-sm text-gray-500">Yükleniyor...</p>
-              )}
-              {!loadingTree && tree && (
-                <ul className="text-sm">{renderTree(tree)}</ul>
-              )}
-            </div>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- reorder tag selection layout to show the tree on the left

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b7dc12ef883248549d30bf44f68ad