### PR TITLE
Add tag description support

### DIFF
--- a/src/components/Tags/TagList.tsx
+++ b/src/components/Tags/TagList.tsx
@@ -97,6 +97,9 @@ export const TagList: React.FC = () => {
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Node ID
                 </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Açıklama
+                </th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
@@ -118,6 +121,9 @@ export const TagList: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-600">
                     {tag.tagNodeId}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {tag.description || '-'}
                   </td>
                 </tr>
               ))}

--- a/src/components/Templates/TemplateTagManager.tsx
+++ b/src/components/Templates/TemplateTagManager.tsx
@@ -90,10 +90,14 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
     const newNodes = Object.values(selected);
     for (const node of newNodes) {
       if (!tags.some((t) => t.tagNodeId === node.nodeId)) {
+        const description = prompt(
+          `${node.displayName} için açıklama (isteğe bağlı)`
+        )?.trim();
         await tagService.create({
           reportTemplateId: templateId,
           tagName: node.displayName,
           tagNodeId: node.nodeId,
+          ...(description ? { description } : {}),
         });
       }
     }
@@ -209,6 +213,9 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Node ID
                     </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Açıklama
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="bg-white divide-y divide-gray-200">
@@ -227,6 +234,9 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-600">
                         {tag.tagNodeId}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                        {tag.description || '-'}
                       </td>
                     </tr>
                   ))}

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -6,6 +6,7 @@ export interface ReportTemplateTagDto {
   reportTemplateId: number;
   tagName: string;
   tagNodeId: string;
+  description?: string;
 }
 
 export const tagService = {


### PR DESCRIPTION
## Summary
- extend `ReportTemplateTagDto` with optional `description`
- display descriptions in tag lists
- prompt for description when creating tags

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ccd56df54832496f748bbe0a39794