### PR TITLE
Add trend dashboard and system info banner

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,124 +1,28 @@
-import React, { useEffect, useState } from 'react';
-import {
-  FileText,
-  Tags,
-  Database,
-  Activity as ActivityIcon,
-  Users,
-  AlertTriangle,
-  TrendingUp,
-  Server
-} from 'lucide-react';
-import { DashboardCard } from './DashboardCard';
-import { SystemStatus } from './SystemStatus';
-import { DataChart } from './DataChart';
-import { dashboardService, DashboardStats, SystemMetric } from '../../services';
-import { dataStore } from '../../store/dataStore';
+import React, { useState } from 'react';
+import { TrendDashboard } from '../Trend/TrendDashboard';
+import { SystemInfo } from './SystemInfo';
 
 export const Dashboard: React.FC = () => {
-  const [stats, setStats] = useState<DashboardStats>(dataStore.getDashboardStats());
-  const [systemMetrics, setSystemMetrics] = useState<SystemMetric[]>(dataStore.getSystemMetrics());
+  const [tab, setTab] = useState<'trend' | 'system'>('trend');
 
-  const normalizeStatus = (status: string) => {
-    const s = status.toLowerCase();
-    if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
-    if (['warning', 'degraded'].includes(s)) return 'warning';
-    return 'good';
-  };
-
-  const overallSystemHealth = React.useMemo(() => {
-    if (systemMetrics.some(m => normalizeStatus(m.status) === 'bad')) return 'bad';
-    if (systemMetrics.some(m => normalizeStatus(m.status) === 'warning')) return 'warning';
-    return 'good';
-  }, [systemMetrics]);
-
-  useEffect(() => {
-    dashboardService
-      .stats()
-      .then(setStats)
-      .catch(() => setStats(dataStore.getDashboardStats()));
-    dashboardService
-      .metrics()
-      .then(setSystemMetrics)
-      .catch(() => setSystemMetrics(dataStore.getSystemMetrics()));
-  }, []);
+  const tabClass = (t: 'trend' | 'system') =>
+    'px-3 py-2 text-sm font-medium rounded-t-md border-b-2 focus:outline-none ' +
+    (tab === t ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500');
 
   return (
-    <div className="space-y-6 px-2">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
-        <div className="flex items-center space-x-2 text-sm text-gray-500">
-          <ActivityIcon className="h-4 w-4" />
-          <span>Son güncelleme: {new Date().toLocaleTimeString('tr-TR')}</span>
-        </div>
+    <div className="px-2">
+      <div className="border-b mb-4">
+        <nav className="flex space-x-4" aria-label="Tabs">
+          <button className={tabClass('trend')} onClick={() => setTab('trend')}>
+            Trend Dashboard
+          </button>
+          <button className={tabClass('system')} onClick={() => setTab('system')}>
+            Sistem Bilgileri
+          </button>
+        </nav>
       </div>
-
-      {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <DashboardCard
-          title="Toplam Şablon"
-          value={stats.totalTemplates}
-          icon={FileText}
-          color="blue"
-        />
-        <DashboardCard
-          title="Aktif Etiket"
-          value={stats.activeTags}
-          icon={Tags}
-          color="green"
-        />
-        <DashboardCard
-          title="24s Veri Noktası"
-          value={stats.dataPoints24h.toLocaleString()}
-          icon={Database}
-          color="blue"
-        />
-        <DashboardCard
-          title="Sistem Uptime"
-          value={stats.uptime}
-          icon={TrendingUp}
-          color="green"
-        />
-      </div>
-
-      {/* System Status and Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <SystemStatus metrics={systemMetrics} />
-        <DataChart />
-      </div>
-
-      {/* Additional Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <DashboardCard
-          title="Aktif Kullanıcı"
-          value={stats.activeUsers}
-          icon={Users}
-          color="blue"
-        />
-        <DashboardCard
-          title="24s Uyarı"
-          value={stats.alerts24h}
-          icon={AlertTriangle}
-          color="yellow"
-        />
-        <DashboardCard
-          title="Sistem Durumu"
-          value={
-            overallSystemHealth === 'good'
-              ? 'Sağlıklı'
-              : overallSystemHealth === 'warning'
-                ? 'Uyarı'
-                : 'Sağlıksız'
-          }
-          icon={Server}
-          color={
-            overallSystemHealth === 'good'
-              ? 'green'
-              : overallSystemHealth === 'warning'
-                ? 'yellow'
-                : 'red'
-          }
-        />
-      </div>
+      {tab === 'trend' ? <TrendDashboard /> : <SystemInfo />}
     </div>
-  );};
+  );
+};
+

--- a/src/components/Dashboard/SystemInfo.tsx
+++ b/src/components/Dashboard/SystemInfo.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from 'react';
+import {
+  FileText,
+  Tags as TagsIcon,
+  Database,
+  Activity as ActivityIcon,
+  Users,
+  AlertTriangle,
+  TrendingUp,
+  Server,
+} from 'lucide-react';
+import { DashboardCard } from './DashboardCard';
+import { SystemStatus } from './SystemStatus';
+import { DataChart } from './DataChart';
+import { dashboardService, DashboardStats, SystemMetric } from '../../services';
+import { dataStore } from '../../store/dataStore';
+
+export const SystemInfo: React.FC = () => {
+  const [stats, setStats] = useState<DashboardStats>(dataStore.getDashboardStats());
+  const [systemMetrics, setSystemMetrics] = useState<SystemMetric[]>(dataStore.getSystemMetrics());
+
+  const normalizeStatus = (status: string) => {
+    const s = status.toLowerCase();
+    if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
+    if (['warning', 'degraded'].includes(s)) return 'warning';
+    return 'good';
+  };
+
+  useEffect(() => {
+    dashboardService
+      .stats()
+      .then(setStats)
+      .catch(() => setStats(dataStore.getDashboardStats()));
+    dashboardService
+      .metrics()
+      .then(setSystemMetrics)
+      .catch(() => setSystemMetrics(dataStore.getSystemMetrics()));
+  }, []);
+
+  const badMetrics = systemMetrics.filter((m) => normalizeStatus(m.status) === 'bad');
+
+  const getBannerMessage = (metric: SystemMetric) => {
+    const name = metric.name.toLowerCase();
+    if (name.includes('opc')) return 'OPC bağlantısı yok';
+    if (name.includes('internet')) return 'İnternet kesildi';
+    return `${metric.name} hatası`;
+  };
+
+  const overallSystemHealth = React.useMemo(() => {
+    if (systemMetrics.some((m) => normalizeStatus(m.status) === 'bad')) return 'bad';
+    if (systemMetrics.some((m) => normalizeStatus(m.status) === 'warning')) return 'warning';
+    return 'good';
+  }, [systemMetrics]);
+
+  return (
+    <div className="space-y-6">
+      {badMetrics.map((m) => (
+        <div
+          key={m.id}
+          className="bg-red-100 text-red-800 px-4 py-2 rounded"
+        >
+          ❗ {getBannerMessage(m)}
+        </div>
+      ))}
+
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
+        <div className="flex items-center space-x-2 text-sm text-gray-500">
+          <ActivityIcon className="h-4 w-4" />
+          <span>Son güncelleme: {new Date().toLocaleTimeString('tr-TR')}</span>
+        </div>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <DashboardCard
+          title="Toplam Şablon"
+          value={stats.totalTemplates}
+          icon={FileText}
+          color="blue"
+        />
+        <DashboardCard
+          title="Aktif Etiket"
+          value={stats.activeTags}
+          icon={TagsIcon}
+          color="green"
+        />
+        <DashboardCard
+          title="24s Veri Noktası"
+          value={stats.dataPoints24h.toLocaleString()}
+          icon={Database}
+          color="blue"
+        />
+        <DashboardCard
+          title="Sistem Uptime"
+          value={stats.uptime}
+          icon={TrendingUp}
+          color="green"
+        />
+      </div>
+
+      {/* System Status and Charts */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <SystemStatus metrics={systemMetrics} />
+        <DataChart />
+      </div>
+
+      {/* Additional Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <DashboardCard
+          title="Aktif Kullanıcı"
+          value={stats.activeUsers}
+          icon={Users}
+          color="blue"
+        />
+        <DashboardCard
+          title="24s Uyarı"
+          value={stats.alerts24h}
+          icon={AlertTriangle}
+          color="yellow"
+        />
+        <DashboardCard
+          title="Sistem Durumu"
+          value={
+            overallSystemHealth === 'good'
+              ? 'Sağlıklı'
+              : overallSystemHealth === 'warning'
+                ? 'Uyarı'
+                : 'Sağlıksız'
+          }
+          icon={Server}
+          color={
+            overallSystemHealth === 'good'
+              ? 'green'
+              : overallSystemHealth === 'warning'
+                ? 'yellow'
+                : 'red'
+          }
+        />
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/Trend/TrendDashboard.tsx
+++ b/src/components/Trend/TrendDashboard.tsx
@@ -1,0 +1,254 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  archiveTagService,
+  ArchiveTagDto,
+  trendService,
+  TrendPoint,
+} from '../../services';
+
+export const TrendDashboard: React.FC = () => {
+  const [tags, setTags] = useState<ArchiveTagDto[]>([]);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const [tagToAdd, setTagToAdd] = useState<number | ''>('');
+  const [start, setStart] = useState(() => {
+    const d = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    return d.toISOString().slice(0, 16);
+  });
+  const [end, setEnd] = useState(() => {
+    const d = new Date();
+    return d.toISOString().slice(0, 16);
+  });
+  const [points, setPoints] = useState<TrendPoint[]>([]);
+  const [realtime, setRealtime] = useState(false);
+
+  useEffect(() => {
+    archiveTagService
+      .list({ index: 0, size: 100 })
+      .then((res) => setTags(res.items))
+      .catch(() => setTags([]));
+  }, []);
+
+  const activeTag = tags.find((t) => t.id === activeId) || null;
+
+  const loadData = useCallback(() => {
+    if (!activeTag) return;
+    trendService
+      .get(activeTag, start + ':00Z', end + ':00Z')
+      .then((res) => setPoints(res.points ?? []))
+      .catch(() => setPoints([]));
+  }, [activeTag, start, end]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (!realtime || !activeTag) return;
+    const interval = setInterval(() => {
+      const now = new Date();
+      const s = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      setStart(s.toISOString().slice(0, 16));
+      setEnd(now.toISOString().slice(0, 16));
+      loadData();
+    }, activeTag.pullInterval * 1000);
+    return () => clearInterval(interval);
+  }, [realtime, activeTag, loadData]);
+
+  const handleAddTag = () => {
+    if (tagToAdd === '' || selectedIds.includes(tagToAdd as number)) return;
+    if (selectedIds.length >= 5) return;
+    const id = Number(tagToAdd);
+    setSelectedIds([...selectedIds, id]);
+    setActiveId(id);
+    setTagToAdd('');
+  };
+
+  const selectedTags = tags.filter((t) => selectedIds.includes(t.id));
+
+  const handleLast24h = () => {
+    const now = new Date();
+    const s = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    setStart(s.toISOString().slice(0, 16));
+    setEnd(now.toISOString().slice(0, 16));
+  };
+
+  const handleExport = () => {
+    const content = document.getElementById('trend-dashboard-content');
+    if (!content) return;
+    const win = window.open('', '', 'width=800,height=600');
+    if (!win) return;
+    win.document.write(
+      '<html><head><title>Trend</title></head><body>' +
+        content.innerHTML +
+        '</body></html>'
+    );
+    win.document.close();
+    win.print();
+  };
+
+  const max = points.length ? Math.max(...points.map((p) => p.value)) : 0;
+  const min = points.length ? Math.min(...points.map((p) => p.value)) : 0;
+  const avg = points.length
+    ? points.reduce((s, p) => s + p.value, 0) / points.length
+    : 0;
+  const maxValue = Math.max(...points.map((d) => d.value), 1);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2 items-end">
+        <select
+          value={tagToAdd}
+          onChange={(e) =>
+            setTagToAdd(e.target.value ? Number(e.target.value) : '')
+          }
+          className="border rounded p-1"
+        >
+          <option value="">Tag seç...</option>
+          {tags
+            .filter((t) => !selectedIds.includes(t.id))
+            .map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.tagName}
+              </option>
+            ))}
+        </select>
+        <button
+          onClick={handleAddTag}
+          disabled={tagToAdd === '' || selectedIds.length >= 5}
+          className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+        >
+          Ekle
+        </button>
+      </div>
+
+      {selectedTags.length > 0 && (
+        <div className="flex space-x-2">
+          {selectedTags.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setActiveId(t.id)}
+              className={`px-3 py-1 rounded ${
+                activeId === t.id
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-200 text-gray-700'
+              }`}
+            >
+              {t.tagName}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {activeTag ? (
+        <div id="trend-dashboard-content">
+          <div className="flex space-x-2 items-end mb-4 mt-2">
+            <div>
+              <label className="text-xs">Başlangıç</label>
+              <input
+                type="datetime-local"
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+                className="border rounded p-1"
+              />
+            </div>
+            <div>
+              <label className="text-xs">Bitiş</label>
+              <input
+                type="datetime-local"
+                value={end}
+                onChange={(e) => setEnd(e.target.value)}
+                className="border rounded p-1"
+              />
+            </div>
+            <button
+              onClick={handleLast24h}
+              className="bg-blue-600 text-white px-2 py-1 rounded"
+            >
+              Son 24 Saat
+            </button>
+            <label className="flex items-center space-x-1 text-xs">
+              <input
+                type="checkbox"
+                checked={realtime}
+                onChange={(e) => setRealtime(e.target.checked)}
+              />
+              <span>Gerçek Zamanlı</span>
+            </label>
+            <button
+              onClick={handleExport}
+              className="ml-auto bg-green-600 text-white px-2 py-1 rounded"
+            >
+              PDF
+            </button>
+          </div>
+
+          <div className="relative h-48 mb-4">
+            <svg viewBox="0 0 400 200" className="w-full h-full">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <line
+                  key={i}
+                  x1="0"
+                  y1={40 * i}
+                  x2="400"
+                  y2={40 * i}
+                  stroke="#f1f5f9"
+                  strokeWidth="1"
+                />
+              ))}
+              <polyline
+                points={points
+                  .map(
+                    (d, i) =>
+                      `${i * (400 / Math.max(points.length - 1, 1))},${200 -
+                        (d.value / maxValue) * 160}`
+                  )
+                  .join(' ')}
+                fill="none"
+                stroke="#3b82f6"
+                strokeWidth="2"
+              />
+              {points.map((d, i) => (
+                <circle
+                  key={d.timestamp}
+                  cx={i * (400 / Math.max(points.length - 1, 1))}
+                  cy={200 - (d.value / maxValue) * 160}
+                  r="4"
+                  fill="#3b82f6"
+                />
+              ))}
+            </svg>
+            <div className="absolute bottom-0 left-0 right-0 flex justify-between text-xs text-gray-500 pt-2">
+              {points.map((d) => (
+                <span key={d.timestamp}>
+                  {new Date(d.timestamp).toLocaleTimeString('tr-TR', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-4 gap-4 text-sm">
+            <div>
+              <span className="font-medium">Max:</span> {max}
+            </div>
+            <div>
+              <span className="font-medium">Min:</span> {min}
+            </div>
+            <div>
+              <span className="font-medium">Ortalama:</span> {avg.toFixed(2)}
+            </div>
+            <div>
+              <span className="font-medium">Toplam:</span> {points.length}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="text-center text-gray-500">Trend görmek için tag seçin.</div>
+      )}
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- Split dashboard into Trend Dashboard and Sistem Bilgileri tabs
- Allow selecting up to five archived tags for real-time trend charts with PDF export
- Show system error banners when metrics report failures

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6891ba1ceec08324aa6de625ebfc8407