### PR TITLE
Fallback to mock data when API unavailable

### DIFF
--- a/src/services/mockData.ts
+++ b/src/services/mockData.ts
@@ -1,0 +1,52 @@
+import { AccessToken } from './authService';
+import { DashboardStats, SystemMetric } from '../types';
+
+type MockHandler = ((body?: string) => unknown) | unknown;
+
+const mockToken: AccessToken = {
+  token:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBnbWFpbC5jb20iLCJyb2xlIjoiYWRtaW4ifQ.mock',
+  refreshToken: 'mock-refresh-token',
+  expiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+};
+
+export const mockResponses: Record<string, MockHandler> = {
+  '/api/auth/login': (body?: string): AccessToken => {
+    try {
+      const { email, password } = body ? JSON.parse(body) : {};
+      if (email === 'admin@gmail.com' && password === '1Q2w3e') {
+        return mockToken;
+      }
+    } catch {
+      // ignore parsing errors
+    }
+    throw new Error('Invalid credentials');
+  },
+  '/api/dashboard': {
+    totalTemplates: 2,
+    activeTags: 10,
+    dataPoints24h: 1234,
+    systemHealth: 'healthy',
+    activeUsers: 1,
+    alerts24h: 0,
+    uptime: '48h',
+  } as DashboardStats,
+  '/api/dashboard/metrics': [
+    {
+      id: '1',
+      name: 'CPU Usage',
+      value: 55,
+      unit: '%',
+      status: 'healthy',
+      lastUpdated: new Date().toISOString(),
+    },
+    {
+      id: '2',
+      name: 'Memory Usage',
+      value: 70,
+      unit: '%',
+      status: 'warning',
+      lastUpdated: new Date().toISOString(),
+    },
+  ] as SystemMetric[],
+};


### PR DESCRIPTION
## Summary
- use mock responses when API requests fail
- add mock login credentials and sample dashboard data for offline testing

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891bb9c37588324929d8217d427cb3a