### PR TITLE
Add trend mocks for archive tag testing

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -50,7 +50,8 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
     }
   } catch (error) {
     clearTimeout(timeoutId);
-    const mock = mockResponses[url];
+    const cleanUrl = url.split('?')[0];
+    const mock = mockResponses[url] || mockResponses[cleanUrl];
     if (mock) {
       console.warn(`Using mock data for ${url} due to API error`, error);
       if (typeof mock === 'function') {

--- a/src/services/mockData.ts
+++ b/src/services/mockData.ts
@@ -1,4 +1,7 @@
 import { AccessToken } from './authService';
+import { ArchiveTagDto } from './archiveTagService';
+import { PaginatedResponse } from './templateService';
+import { TrendResponse } from './trendService';
 import { DashboardStats, SystemMetric } from '../types';
 
 type MockHandler = ((body?: string) => unknown) | unknown;
@@ -8,6 +11,32 @@ const mockToken: AccessToken = {
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBnbWFpbC5jb20iLCJyb2xlIjoiYWRtaW4ifQ.mock',
   refreshToken: 'mock-refresh-token',
   expiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+};
+
+const mockArchiveTags: ArchiveTagDto[] = [
+  {
+    id: 1,
+    tagName: 'Temperature Sensor',
+    tagNodeId: 'node1',
+    pullInterval: 10,
+    description: 'Mock temperature data',
+  },
+  {
+    id: 2,
+    tagName: 'Pressure Sensor',
+    tagNodeId: 'node2',
+    pullInterval: 15,
+    description: 'Mock pressure data',
+  },
+];
+
+const generateTrend = (): TrendResponse => {
+  const now = Date.now();
+  const points = Array.from({ length: 24 }, (_, i) => ({
+    timestamp: new Date(now - (23 - i) * 60 * 60 * 1000).toISOString(),
+    value: Math.round(50 + 20 * Math.sin(i / 3)),
+  }));
+  return { points };
 };
 
 export const mockResponses: Record<string, MockHandler> = {
@@ -49,4 +78,17 @@ export const mockResponses: Record<string, MockHandler> = {
       lastUpdated: new Date().toISOString(),
     },
   ] as SystemMetric[],
+  '/api/archivetags/list': {
+    items: mockArchiveTags,
+    index: 0,
+    size: mockArchiveTags.length,
+    count: mockArchiveTags.length,
+    pages: 1,
+    hasPrevious: false,
+    hasNext: false,
+  } as PaginatedResponse<ArchiveTagDto>,
+  '/api/archivetags/1': mockArchiveTags[0],
+  '/api/archivetags/2': mockArchiveTags[1],
+  '/api/archivetags/1/trend': () => generateTrend(),
+  '/api/archivetags/2/trend': () => generateTrend(),
 };


### PR DESCRIPTION
## Summary
- add mock archive tags and trend series
- support mock lookup without query strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891db1979a0832489da47468b3417fe