### PR TITLE
feat: collapse sidebar on hover

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -62,7 +62,9 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeTab, onTabChange }) => {
                 }`}
               >
                 <Icon className="h-5 w-5 flex-shrink-0" />
-                {!isCollapsed && <span>{item.label}</span>}
+                {!isCollapsed && (
+                  <span className="flex-1 truncate">{item.label}</span>
+                )}
               </button>
             );
           })}


### PR DESCRIPTION
## Summary
- add collapsible sidebar that expands on hover
- hide menu labels and center icons when collapsed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892f9d2a5e883258da9c079aec05790