### PR TITLE
feat: show system status in header

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { User, LogOut, Settings } from 'lucide-react';
 import { authStore } from '../../store/authStore';
+import { SystemStatusIndicator } from './SystemStatusIndicator';
 
 interface HeaderProps {
   onLogout: () => void;
@@ -27,6 +28,7 @@ export const Header: React.FC<HeaderProps> = ({ onLogout, onOpenUserSettings }) 
           </div>
 
           <div className="flex items-center space-x-4">
+            <SystemStatusIndicator />
             <button
               onClick={onOpenUserSettings}
               className="flex items-center space-x-2 focus:outline-none hover:bg-gray-100 px-2 py-1 rounded-md"

--- a/src/components/Layout/SystemStatusIndicator.tsx
+++ b/src/components/Layout/SystemStatusIndicator.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { AlertTriangle, CheckCircle } from 'lucide-react';
+import { dashboardService } from '../../services';
+import { dataStore } from '../../store/dataStore';
+import { SystemMetric } from '../../types';
+
+const normalizeStatus = (status: string) => {
+  const s = status.toLowerCase();
+  if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
+  if (['warning', 'degraded'].includes(s)) return 'warning';
+  return 'good';
+};
+
+const getBannerMessage = (metric: SystemMetric) => {
+  const name = metric.name.toLowerCase();
+  if (name.includes('opc')) return 'OPC bağlantısı yok';
+  if (name.includes('internet')) return 'İnternet kesildi';
+  return `${metric.name} hatası`;
+};
+
+export const SystemStatusIndicator: React.FC = () => {
+  const [metrics, setMetrics] = useState<SystemMetric[]>(dataStore.getSystemMetrics());
+
+  useEffect(() => {
+    dashboardService
+      .metrics()
+      .then(setMetrics)
+      .catch(() => setMetrics(dataStore.getSystemMetrics()));
+  }, []);
+
+  const badMetric = metrics.find(m => normalizeStatus(m.status) === 'bad');
+  const warningMetric = metrics.find(m => normalizeStatus(m.status) === 'warning');
+
+  if (badMetric) {
+    return (
+      <div className="flex items-center text-red-600 text-sm">
+        <AlertTriangle className="h-5 w-5 mr-1" />
+        {getBannerMessage(badMetric)}
+      </div>
+    );
+  }
+
+  if (warningMetric) {
+    return (
+      <div className="flex items-center text-yellow-600 text-sm">
+        <AlertTriangle className="h-5 w-5 mr-1" />
+        {getBannerMessage(warningMetric)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center text-green-600 text-sm">
+      <CheckCircle className="h-5 w-5 mr-1" />
+      Sistem Sağlıklı
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add system status indicator component
- display system health next to user info in header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68930064736c8325bab7275b6506456b