### PR TITLE
Refactor report templates to use archive tags

### DIFF
--- a/src/components/Templates/TemplateEditForm.tsx
+++ b/src/components/Templates/TemplateEditForm.tsx
@@ -10,8 +10,6 @@ interface TemplateEditFormProps {
 
 export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSuccess, onCancel }) => {
   const [name, setName] = useState('');
-  const [opcEndpoint, setOpcEndpoint] = useState('');
-  const [pullInterval, setPullInterval] = useState(0);
   const [isActive, setIsActive] = useState(true);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -20,8 +18,6 @@ export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSucces
   useEffect(() => {
     templateService.getById(id).then((res) => {
       setName(res.name);
-      setOpcEndpoint(res.opcEndpoint);
-      setPullInterval(res.pullInterval);
       setIsActive(!!res.isActive);
     });
   }, [id]);
@@ -31,7 +27,7 @@ export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSucces
     setError('');
     setIsLoading(true);
     try {
-      await templateService.update({ id, name, opcEndpoint, pullInterval, isActive });
+      await templateService.update({ id, name, isActive });
       setShowToast(true);
       setTimeout(() => {
         setShowToast(false);
@@ -53,26 +49,6 @@ export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSucces
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            required
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">OPC Endpoint</label>
-          <input
-            type="text"
-            value={opcEndpoint}
-            onChange={(e) => setOpcEndpoint(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            required
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Çekme Aralığı (s)</label>
-          <input
-            type="number"
-            value={pullInterval}
-            onChange={(e) => setPullInterval(Number(e.target.value))}
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -174,14 +174,6 @@ export const TemplateList: React.FC = () => {
 
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <span className="text-gray-600">OPC Endpoint:</span>
-                <span className="font-mono text-xs">{template.opcEndpoint}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-gray-600">Çekme Aralığı:</span>
-                <span>{template.pullInterval}s</span>
-              </div>
-              <div className="flex justify-between">
                 <span className="text-gray-600">Etiket Sayısı:</span>
                 <span>{tags[template.id] || 0}</span>
               </div>

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -3,8 +3,6 @@ import { api } from './api';
 export interface ReportTemplateDto {
   id: number;
   name: string;
-  opcEndpoint: string;
-  pullInterval: number;
   isActive?: boolean;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,8 +12,6 @@ export interface ReportTemplate {
   id: string;
   name: string;
   description: string;
-  opcEndpoint: string;
-  collectionInterval: number; // in seconds
   createdBy: string;
   createdAt: string;
   isActive: boolean;


### PR DESCRIPTION
## Summary
- drop opc endpoint and pull interval fields from templates
- allow selecting archive tags when creating report templates
- simplify template edit and listing views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a5b21edc8324af7b7b5f33927a41