### PR TITLE
fix: import Tags icon in sidebar

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -7,7 +7,8 @@ import {
   Shield,
   Key,
   UserCog,
-  Archive
+  Archive,
+  Tags
 } from 'lucide-react';
 import { authStore } from '../../store/authStore';
 


### PR DESCRIPTION
## Summary
- import Tags icon for sidebar menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894ab13a59483249f96d5a5e3cef65c