### PR TITLE
Handle localized dashboard metrics

### DIFF
--- a/src/components/Dashboard/SystemInfo.tsx
+++ b/src/components/Dashboard/SystemInfo.tsx
@@ -28,8 +28,22 @@ export const SystemInfo: React.FC = () => {
 
   const normalizeStatus = (status: string) => {
     const s = status.toLowerCase();
-    if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
-    if (['warning', 'degraded'].includes(s)) return 'warning';
+    if (
+      [
+        'bad',
+        'critical',
+        'error',
+        'failed',
+        'disconnected',
+        'bağlı değil',
+        'bagli degil',
+        'kötü',
+        'kotu',
+        'offline',
+      ].includes(s)
+    )
+      return 'bad';
+    if (['warning', 'degraded', 'uyarı', 'uyari'].includes(s)) return 'warning';
     return 'good';
   };
 

--- a/src/components/Dashboard/SystemStatus.tsx
+++ b/src/components/Dashboard/SystemStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CheckCircle, AlertCircle, XCircle } from 'lucide-react';
-import { SystemMetric } from '../../types';
+import { SystemMetric } from '../../services';
 
 interface SystemStatusProps {
   metrics: SystemMetric[];
@@ -9,8 +9,22 @@ interface SystemStatusProps {
 export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
   const normalizeStatus = (status: string) => {
     const s = status.toLowerCase();
-    if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
-    if (['warning', 'degraded'].includes(s)) return 'warning';
+    if (
+      [
+        'bad',
+        'critical',
+        'error',
+        'failed',
+        'disconnected',
+        'bağlı değil',
+        'bagli degil',
+        'kötü',
+        'kotu',
+        'offline',
+      ].includes(s)
+    )
+      return 'bad';
+    if (['warning', 'degraded', 'uyarı', 'uyari'].includes(s)) return 'warning';
     return 'good';
   };
 
@@ -59,6 +73,9 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
   const formatValue = (metric: SystemMetric) => {
     if (metric.value === 1) {
       return 'Bağlı';
+    }
+    if (metric.value === 0 && !metric.unit) {
+      return 'Bağlı Değil';
     }
     return `${metric.value} ${metric.unit}`.trim();
   };

--- a/src/components/Layout/SystemStatusIndicator.tsx
+++ b/src/components/Layout/SystemStatusIndicator.tsx
@@ -1,12 +1,25 @@
 import React, { useEffect, useState } from 'react';
 import { AlertTriangle, CheckCircle } from 'lucide-react';
-import { dashboardService } from '../../services';
-import { SystemMetric } from '../../types';
+import { dashboardService, SystemMetric } from '../../services';
 
 const normalizeStatus = (status: string) => {
   const s = status.toLowerCase();
-  if (['bad', 'critical', 'error', 'failed', 'disconnected'].includes(s)) return 'bad';
-  if (['warning', 'degraded'].includes(s)) return 'warning';
+  if (
+    [
+      'bad',
+      'critical',
+      'error',
+      'failed',
+      'disconnected',
+      'bağlı değil',
+      'bagli degil',
+      'kötü',
+      'kotu',
+      'offline',
+    ].includes(s)
+  )
+    return 'bad';
+  if (['warning', 'degraded', 'uyarı', 'uyari'].includes(s)) return 'warning';
   return 'good';
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,7 +42,7 @@ export interface SystemMetric {
   name: string;
   value: number;
   unit: string;
-  status: 'healthy' | 'warning' | 'critical';
+  status: string;
   lastUpdated: string;
 }
 


### PR DESCRIPTION
## Summary
- normalize dashboard status values to handle Turkish messages
- show connection status text when value is zero
- align SystemMetric type with API and use shared service types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af8a3b52c83249e398b31435e2858