### PR TITLE
Fix duplicate keys in dashboard metrics

### DIFF
--- a/src/components/Dashboard/SystemInfo.tsx
+++ b/src/components/Dashboard/SystemInfo.tsx
@@ -75,9 +75,9 @@ export const SystemInfo: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      {badMetrics.map((m) => (
+      {badMetrics.map((m, idx) => (
         <div
-          key={m.id}
+          key={`${m.id}-${idx}`}
           className="bg-red-100 text-red-800 px-4 py-2 rounded"
         >
           ❗ {getBannerMessage(m)}

--- a/src/components/Dashboard/SystemStatus.tsx
+++ b/src/components/Dashboard/SystemStatus.tsx
@@ -87,7 +87,7 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
       <div className="space-y-4">
         {metrics.map((metric, idx) => (
           <div
-            key={metric.id ?? idx}
+            key={`${metric.id}-${idx}`}
             className={`p-4 rounded-lg border ${getStatusColor(metric.status)}`}
           >
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- ensure dashboard system metrics use unique keys to avoid React warnings
- provide unique keys for bad metric banner entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689afddea1c88324933b9b5773a7dabf