### PR TITLE
fix: resolve dashboard warnings

### DIFF
--- a/src/components/Dashboard/DataChart.tsx
+++ b/src/components/Dashboard/DataChart.tsx
@@ -23,8 +23,16 @@ export const DataChart: React.FC = () => {
 
     const query: DynamicQuery = {
       filters: [
-        { field: 'timestamp', operator: 'gte', value: start.toISOString() },
-        { field: 'timestamp', operator: 'lte', value: end.toISOString() },
+        {
+          field: 'timestamp',
+          operator: 'GreaterThanOrEqual',
+          value: start.toISOString(),
+        },
+        {
+          field: 'timestamp',
+          operator: 'LessThanOrEqual',
+          value: end.toISOString(),
+        },
       ],
       sorts: [{ field: 'timestamp', direction: 'asc' }],
     };

--- a/src/components/Dashboard/SystemStatus.tsx
+++ b/src/components/Dashboard/SystemStatus.tsx
@@ -87,7 +87,7 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
       <div className="space-y-4">
         {metrics.map((metric, idx) => (
           <div
-            key={`${metric.id}-${idx}`}
+            key={metric.id ?? idx}
             className={`p-4 rounded-lg border ${getStatusColor(metric.status)}`}
           >
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- use id fallback to index for SystemStatus keys
- replace gte/lte filters with compatible operators in DataChart

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dc39675a08324a8649a9726ed79b8