### PR TITLE
fix: use PUT for archive tag update

### DIFF
--- a/src/services/archiveTagService.ts
+++ b/src/services/archiveTagService.ts
@@ -14,7 +14,7 @@ export const archiveTagService = {
   create: (data: Omit<ArchiveTagDto, 'id'>) =>
     api.post<ArchiveTagDto>('/api/archivetags', data),
   update: (data: ArchiveTagDto) =>
-    api.put<ArchiveTagDto>('/api/archivetags', data),
+    api.put<ArchiveTagDto>(`/api/archivetags/${data.id}`, data),
   delete: (id: number) => api.delete<unknown>(`/api/archivetags/${id}`),
   list: (page: PageRequest, query?: DynamicQuery) =>
     api.post<PaginatedResponse<ArchiveTagDto>>(


### PR DESCRIPTION
## Summary
- ensure archive tag edits issue a PUT request including tag id

## Testing
- `npm test` (fails: Missing script: test)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac10002bb883249ef07fb0dc4a3b95