### PR TITLE
Align ArchiveTag model with new API schema

### DIFF
--- a/src/components/ArchiveTags/ArchiveTagList.tsx
+++ b/src/components/ArchiveTags/ArchiveTagList.tsx
@@ -17,13 +17,11 @@ export const ArchiveTagList: React.FC = () => {
   const [tree, setTree] = useState<TreeNode | null>(null);
   const [selected, setSelected] = useState<Record<string, TreeNode>>({});
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
-  const [interval, setInterval] = useState(10);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [trendTag, setTrendTag] = useState<ArchiveTagDto | null>(null);
   const [editTag, setEditTag] = useState<ArchiveTagDto | null>(null);
   const [isTreeLoading, setIsTreeLoading] = useState(false);
   const isAdmin = authStore.getCurrentUser()?.role === 'admin';
-  const intervals = [1, 5, 10, 20, 30, 60, 300, 600, 3600, 86400];
 
   const loadTags = () =>
     archiveTagService
@@ -115,7 +113,8 @@ export const ArchiveTagList: React.FC = () => {
       await archiveTagService.create({
         tagName: node.displayName,
         tagNodeId: node.nodeId,
-        pullInterval: interval,
+        type: 0,
+        isActive: true,
       });
     }
     setSelected({});
@@ -194,7 +193,10 @@ export const ArchiveTagList: React.FC = () => {
                   Açıklama
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Çekim Aralığı
+                  Tip
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Aktif
                 </th>
               </tr>
             </thead>
@@ -238,7 +240,10 @@ export const ArchiveTagList: React.FC = () => {
                     {tag.description || ''}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {tag.pullInterval}
+                    {tag.type}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {tag.isActive ? 'Aktif' : 'Pasif'}
                   </td>
                 </tr>
               ))}
@@ -268,21 +273,7 @@ export const ArchiveTagList: React.FC = () => {
                 X
               </button>
             </div>
-            <div className="flex justify-between items-center p-4 border-b space-x-4">
-              <div className="flex items-center space-x-2">
-                <label className="text-sm">Çekim Süresi</label>
-                <select
-                  value={interval}
-                  onChange={(e) => setInterval(Number(e.target.value))}
-                  className="border rounded-md p-1"
-                >
-                  {intervals.map((i) => (
-                    <option key={i} value={i}>
-                      {i}
-                    </option>
-                  ))}
-                </select>
-              </div>
+            <div className="flex justify-end items-center p-4 border-b space-x-4">
               <div className="space-x-2">
                 <button
                   onClick={fetchTree}
@@ -353,17 +344,24 @@ export const ArchiveTagList: React.FC = () => {
                 />
               </div>
               <div>
-                <label className="block text-sm">Çekim Aralığı</label>
+                <label className="block text-sm">Tip</label>
                 <input
                   type="number"
-                  value={editTag.pullInterval}
+                  value={editTag.type}
                   onChange={(e) =>
-                    setEditTag({
-                      ...editTag!,
-                      pullInterval: Number(e.target.value),
-                    })
+                    setEditTag({ ...editTag!, type: Number(e.target.value) })
                   }
                   className="mt-1 w-full border rounded-md p-2"
+                />
+              </div>
+              <div className="flex items-center space-x-2">
+                <label className="text-sm">Aktif</label>
+                <input
+                  type="checkbox"
+                  checked={editTag.isActive}
+                  onChange={(e) =>
+                    setEditTag({ ...editTag!, isActive: e.target.checked })
+                  }
                 />
               </div>
             </div>

--- a/src/components/Templates/TemplateCreateForm.tsx
+++ b/src/components/Templates/TemplateCreateForm.tsx
@@ -145,9 +145,6 @@ export const TemplateCreateForm: React.FC<TemplateCreateFormProps> = ({ onSucces
                   <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Node ID
                   </th>
-                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Çekim Aralığı
-                  </th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
@@ -162,7 +159,6 @@ export const TemplateCreateForm: React.FC<TemplateCreateFormProps> = ({ onSucces
                     </td>
                     <td className="px-4 py-2 text-sm text-gray-900">{tag.tagName}</td>
                     <td className="px-4 py-2 text-sm font-mono text-gray-600">{tag.tagNodeId}</td>
-                    <td className="px-4 py-2 text-sm text-gray-900">{tag.pullInterval}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/components/Templates/TemplateTagManager.tsx
+++ b/src/components/Templates/TemplateTagManager.tsx
@@ -138,9 +138,6 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Node ID
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Çekim Aralığı
-                    </th>
                   </tr>
                 </thead>
                 <tbody className="bg-white divide-y divide-gray-200">
@@ -158,9 +155,6 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-600">
                         {tag.tagNodeId}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        {tag.pullInterval}
                       </td>
                     </tr>
                   ))}

--- a/src/components/Trend/TrendDashboard.tsx
+++ b/src/components/Trend/TrendDashboard.tsx
@@ -44,16 +44,16 @@ export const TrendDashboard: React.FC = () => {
   }, [loadData]);
 
   useEffect(() => {
-    if (!realtime || !activeTag) return;
-    const interval = setInterval(() => {
-      const now = new Date();
-      const s = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-      setStart(s.toISOString().slice(0, 16));
-      setEnd(now.toISOString().slice(0, 16));
-      loadData();
-    }, activeTag.pullInterval * 1000);
-    return () => clearInterval(interval);
-  }, [realtime, activeTag, loadData]);
+      if (!realtime || !activeTag) return;
+      const interval = setInterval(() => {
+        const now = new Date();
+        const s = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        setStart(s.toISOString().slice(0, 16));
+        setEnd(now.toISOString().slice(0, 16));
+        loadData();
+      }, 5000);
+      return () => clearInterval(interval);
+    }, [realtime, activeTag, loadData]);
 
   const handleAddTag = () => {
     if (tagToAdd === '' || selectedIds.includes(tagToAdd as number)) return;

--- a/src/components/Trend/TrendModal.tsx
+++ b/src/components/Trend/TrendModal.tsx
@@ -20,7 +20,7 @@ export const TrendModal: React.FC<TrendModalProps> = ({ tag, onClose }) => {
     return d.toISOString().slice(0, 16);
   });
   const [points, setPoints] = useState<TrendPoint[]>([]);
-  const [realtime, setRealtime] = useState(false);
+    const [realtime, setRealtime] = useState(false);
 
   const loadData = useCallback(() => {
     trendService
@@ -34,16 +34,16 @@ export const TrendModal: React.FC<TrendModalProps> = ({ tag, onClose }) => {
   }, [loadData]);
 
   useEffect(() => {
-    if (!realtime) return;
-    const interval = setInterval(() => {
-      const now = new Date();
-      const s = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-      setStart(s.toISOString().slice(0, 16));
-      setEnd(now.toISOString().slice(0, 16));
-      loadData();
-    }, tag.pullInterval * 1000);
-    return () => clearInterval(interval);
-  }, [realtime, tag, loadData]);
+      if (!realtime) return;
+      const interval = setInterval(() => {
+        const now = new Date();
+        const s = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        setStart(s.toISOString().slice(0, 16));
+        setEnd(now.toISOString().slice(0, 16));
+        loadData();
+      }, 5000);
+      return () => clearInterval(interval);
+    }, [realtime, tag, loadData]);
 
   const max = points.length ? Math.max(...points.map((p) => p.value)) : 0;
   const min = points.length ? Math.min(...points.map((p) => p.value)) : 0;
@@ -83,10 +83,11 @@ export const TrendModal: React.FC<TrendModalProps> = ({ tag, onClose }) => {
         </div>
 
         <div className="grid grid-cols-2 gap-4 text-sm mb-4">
-          <div><span className="font-medium">Node Id:</span> {tag.tagNodeId}</div>
-          <div><span className="font-medium">Açıklama:</span> {tag.description ?? '-'}</div>
-          <div><span className="font-medium">Kayıt Aralığı:</span> {tag.pullInterval}s</div>
-        </div>
+            <div><span className="font-medium">Node Id:</span> {tag.tagNodeId}</div>
+            <div><span className="font-medium">Açıklama:</span> {tag.description ?? '-'}</div>
+            <div><span className="font-medium">Tip:</span> {tag.type}</div>
+            <div><span className="font-medium">Durum:</span> {tag.isActive ? 'Aktif' : 'Pasif'}</div>
+          </div>
 
         <div className="flex space-x-2 items-end mb-4">
           <div>

--- a/src/services/archiveTagService.ts
+++ b/src/services/archiveTagService.ts
@@ -5,8 +5,9 @@ export interface ArchiveTagDto {
   id: number;
   tagName: string;
   tagNodeId: string;
-  pullInterval: number;
   description?: string;
+  type: number;
+  isActive: boolean;
 }
 
 export const archiveTagService = {


### PR DESCRIPTION
## Summary
- include `type` and `isActive` in `ArchiveTagDto` and remove `pullInterval`
- update ArchiveTag list, create, and edit views to use new fields and drop interval selection
- drop pull interval columns from template tag selectors and adapt trend views to fixed polling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1159bcb08324b0db6c99314f900a