### PR TITLE
Refine archive tag columns and API integration

### DIFF
--- a/src/components/ArchiveTags/ArchiveTagList.tsx
+++ b/src/components/ArchiveTags/ArchiveTagList.tsx
@@ -174,33 +174,30 @@ export const ArchiveTagList: React.FC = () => {
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
         <div className="overflow-auto h-[calc(100vh-12rem)]">
           <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                {isAdmin && (
-                  <>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Düzenle
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Sil
-                    </th>
-                  </>
-                )}
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Etiket Adı
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Açıklama
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Tip
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Aktif
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  {isAdmin && (
+                    <>
+                      <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Düzenle
+                      </th>
+                      <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Sil
+                      </th>
+                    </>
+                  )}
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Etiket Adı
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Açıklama
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Çekim Aralığı
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
               {filteredTags.map((tag) => (
                 <tr
                   key={tag.id}
@@ -209,7 +206,7 @@ export const ArchiveTagList: React.FC = () => {
                 >
                   {isAdmin && (
                     <>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                      <td className="px-2 py-4 whitespace-nowrap text-sm">
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
@@ -220,7 +217,7 @@ export const ArchiveTagList: React.FC = () => {
                           <Pencil className="h-4 w-4" />
                         </button>
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                      <td className="px-2 py-4 whitespace-nowrap text-sm">
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
@@ -241,9 +238,6 @@ export const ArchiveTagList: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                     {tag.type}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {tag.isActive ? 'Aktif' : 'Pasif'}
                   </td>
                 </tr>
               ))}
@@ -343,17 +337,17 @@ export const ArchiveTagList: React.FC = () => {
                   className="mt-1 w-full border rounded-md p-2"
                 />
               </div>
-              <div>
-                <label className="block text-sm">Tip</label>
-                <input
-                  type="number"
-                  value={editTag.type}
-                  onChange={(e) =>
-                    setEditTag({ ...editTag!, type: Number(e.target.value) })
-                  }
-                  className="mt-1 w-full border rounded-md p-2"
-                />
-              </div>
+                <div>
+                  <label className="block text-sm">Çekim Aralığı</label>
+                  <input
+                    type="number"
+                    value={editTag.type}
+                    onChange={(e) =>
+                      setEditTag({ ...editTag!, type: Number(e.target.value) })
+                    }
+                    className="mt-1 w-full border rounded-md p-2"
+                  />
+                </div>
               <div className="flex items-center space-x-2">
                 <label className="text-sm">Aktif</label>
                 <input

--- a/src/components/Trend/TrendModal.tsx
+++ b/src/components/Trend/TrendModal.tsx
@@ -85,7 +85,7 @@ export const TrendModal: React.FC<TrendModalProps> = ({ tag, onClose }) => {
         <div className="grid grid-cols-2 gap-4 text-sm mb-4">
             <div><span className="font-medium">Node Id:</span> {tag.tagNodeId}</div>
             <div><span className="font-medium">Açıklama:</span> {tag.description ?? '-'}</div>
-            <div><span className="font-medium">Tip:</span> {tag.type}</div>
+            <div><span className="font-medium">Çekim Aralığı:</span> {tag.type}</div>
             <div><span className="font-medium">Durum:</span> {tag.isActive ? 'Aktif' : 'Pasif'}</div>
           </div>
 

--- a/src/services/archiveTagService.ts
+++ b/src/services/archiveTagService.ts
@@ -15,7 +15,7 @@ export const archiveTagService = {
   create: (data: Omit<ArchiveTagDto, 'id'>) =>
     api.post<ArchiveTagDto>('/api/archivetags', data),
   update: (data: ArchiveTagDto) =>
-    api.put<ArchiveTagDto>(`/api/archivetags/${data.id}`, data),
+    api.put<ArchiveTagDto>('/api/archivetags', data),
   delete: (id: number) => api.delete<unknown>(`/api/archivetags/${id}`),
   list: (page: PageRequest, query?: DynamicQuery) =>
     api.post<PaginatedResponse<ArchiveTagDto>>(


### PR DESCRIPTION
## Summary
- Update archive tag service to use body-based update endpoint
- Replace type/active columns with Çekim Aralığı and tighten Edit/Delete spacing
- Show polling interval in edit form and trend modal

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1655e7388324b4c910adb8821a5c