### PR TITLE
Align ReportTemplates API calls with backend spec

### DIFF
--- a/src/components/Templates/TemplateEditForm.tsx
+++ b/src/components/Templates/TemplateEditForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { templateService } from '../../services';
 import { SimpleToast } from '../SimpleToast';
+import { authStore } from '../../store/authStore';
 
 interface TemplateEditFormProps {
   id: number;
@@ -15,7 +16,9 @@ export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSucces
   const [showToast, setShowToast] = useState(false);
 
   useEffect(() => {
-    templateService.getById(id).then((res) => {
+    const currentUser = authStore.getCurrentUser();
+    if (!currentUser) return;
+    templateService.getById(id, currentUser.id).then((res) => {
       setName(res.name);
     });
   }, [id]);

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -8,6 +8,7 @@ import {
 import { templateController } from '../../controllers/templateController';
 import { ConfirmToast } from '../ConfirmToast';
 import { TemplateCreateForm } from './TemplateCreateForm';
+import { authStore } from '../../store/authStore';
 
 export const TemplateList: React.FC = () => {
   const [templates, setTemplates] = useState<ReportTemplateDto[]>([]);
@@ -17,8 +18,13 @@ export const TemplateList: React.FC = () => {
   const [deleteId, setDeleteId] = useState<number | null>(null);
 
   const loadData = () => {
+    const currentUser = authStore.getCurrentUser();
+    if (!currentUser) {
+      setTemplates([]);
+      return;
+    }
     templateService
-      .list({ index: 0, size: 50 })
+      .list({ index: 0, size: 50 }, currentUser.id)
       .then((res) => setTemplates(res.items))
       .catch(() => setTemplates([]));
     tagService

--- a/src/components/Templates/TemplateTagManager.tsx
+++ b/src/components/Templates/TemplateTagManager.tsx
@@ -8,6 +8,7 @@ import {
   ArchiveTagDto,
 } from '../../services';
 import { ConfirmToast } from '../ConfirmToast';
+import { authStore } from '../../store/authStore';
 
 interface TemplateTagManagerProps {
   templateId: number;
@@ -43,18 +44,21 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
   }, []);
 
   useEffect(() => {
-    templateService
-      .getById(templateId)
-      .then((res) => {
-        setTemplateName(res.name);
-        setCreatedBy(res.createdByUserId);
-        setIsShared(res.isShared);
-      })
-      .catch(() => {
-        setTemplateName('');
-        setCreatedBy('');
-        setIsShared(false);
-      });
+    const currentUser = authStore.getCurrentUser();
+    if (currentUser) {
+      templateService
+        .getById(templateId, currentUser.id)
+        .then((res) => {
+          setTemplateName(res.name);
+          setCreatedBy(res.createdByUserId);
+          setIsShared(res.isShared);
+        })
+        .catch(() => {
+          setTemplateName('');
+          setCreatedBy('');
+          setIsShared(false);
+        });
+    }
     loadTags();
     loadAvailable();
   }, [templateId, loadTags, loadAvailable]);

--- a/src/controllers/templateController.ts
+++ b/src/controllers/templateController.ts
@@ -1,11 +1,36 @@
-import { templateService, PageRequest, PaginatedResponse, ReportTemplateDto } from '../services/templateService';
+import {
+  templateService,
+  PageRequest,
+  PaginatedResponse,
+  ReportTemplateDto,
+  ReportTemplateCreateDto,
+  ReportTemplateUpdateDto,
+  DynamicQuery,
+} from '../services/templateService';
 
 export const templateController = {
-  async list(page: PageRequest = { index: 0, size: 50 }): Promise<PaginatedResponse<ReportTemplateDto>> {
-    return await templateService.list(page);
+  async list(
+    page: PageRequest = { index: 0, size: 50 },
+    userId: string,
+    query?: DynamicQuery
+  ): Promise<PaginatedResponse<ReportTemplateDto>> {
+    return await templateService.list(page, userId, query);
+  },
+
+  async get(id: number, userId: string): Promise<ReportTemplateDto> {
+    return await templateService.getById(id, userId);
+  },
+
+  async create(data: ReportTemplateCreateDto): Promise<ReportTemplateDto> {
+    return await templateService.create(data);
+  },
+
+  async update(data: ReportTemplateUpdateDto): Promise<ReportTemplateDto> {
+    return await templateService.update(data);
   },
 
   async delete(id: number): Promise<void> {
-    await templateService.deleteReportTemplateAsync(id);
+    await templateService.delete(id);
   },
 };
+

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -40,17 +40,16 @@ export interface PaginatedResponse<T> {
 }
 
 export const templateService = {
-  getById: (id: number) => api.get<ReportTemplateDto>(`/api/reporttemplates/${id}`),
+  getById: (id: number, userId: string) =>
+    api.get<ReportTemplateDto>(`/api/ReportTemplates/${id}?userId=${userId}`),
   create: (data: ReportTemplateCreateDto) =>
-    api.post<ReportTemplateDto>('/api/reporttemplates', data),
+    api.post<ReportTemplateDto>('/api/ReportTemplates', data),
   update: (data: ReportTemplateUpdateDto) =>
-    api.put<ReportTemplateDto>('/api/reporttemplates', data),
-  delete: (id: number) => api.delete<unknown>(`/api/reporttemplates/${id}`),
-  deleteReportTemplateAsync: (id: number) =>
-    api.delete<unknown>(`/api/ReportTemplates/${id}`),
-  list: (_page: PageRequest, query?: DynamicQuery) =>
+    api.put<ReportTemplateDto>('/api/ReportTemplates', data),
+  delete: (id: number) => api.delete<unknown>(`/api/ReportTemplates/${id}`),
+  list: (page: PageRequest, userId: string, query?: DynamicQuery) =>
     api.post<PaginatedResponse<ReportTemplateDto>>(
-      '/api/ReportTemplates/list',
+      `/api/ReportTemplates/list?PageNumber=${page.index + 1}&PageSize=${page.size}&userId=${userId}`,
       query ?? { filters: [], sorts: [] }
     ),
 };


### PR DESCRIPTION
## Summary
- update template service endpoints to include user context and proper query params
- expand template controller to wrap create, update, get, delete and listing operations
- ensure template components pass current user ID when fetching templates

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac1fe0e3508324be625050f51c8e7e