### PR TITLE
Add capture interval presets and rename tag archive menu

### DIFF
--- a/src/components/ArchiveTags/ArchiveTagList.tsx
+++ b/src/components/ArchiveTags/ArchiveTagList.tsx
@@ -9,6 +9,7 @@ import {
 import { ConfirmToast } from '../ConfirmToast';
 import { authStore } from '../../store/authStore';
 import { TrendModal } from '../Trend/TrendModal';
+import { intervalOptions, formatInterval } from '../../constants/intervalOptions';
 
 export const ArchiveTagList: React.FC = () => {
   const [tags, setTags] = useState<ArchiveTagDto[]>([]);
@@ -113,7 +114,7 @@ export const ArchiveTagList: React.FC = () => {
       await archiveTagService.create({
         tagName: node.displayName,
         tagNodeId: node.nodeId,
-        type: 0,
+        type: intervalOptions[0].value,
         isActive: true,
       });
     }
@@ -230,7 +231,7 @@ export const ArchiveTagList: React.FC = () => {
                     {tag.description || ''}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {tag.type}
+                    {formatInterval(tag.type)}
                   </td>
                 </tr>
               ))}
@@ -332,14 +333,19 @@ export const ArchiveTagList: React.FC = () => {
               </div>
                 <div>
                   <label className="block text-sm">Çekim Aralığı</label>
-                  <input
-                    type="number"
+                  <select
                     value={editTag.type}
                     onChange={(e) =>
                       setEditTag({ ...editTag!, type: Number(e.target.value) })
                     }
                     className="mt-1 w-full border rounded-md p-2"
-                  />
+                  >
+                    {intervalOptions.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
                 </div>
               <div className="flex items-center space-x-2">
                 <label className="text-sm">Aktif</label>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -23,7 +23,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeTab, onTabChange }) => {
   const menuItems = [
     { id: 'dashboard', label: 'Anasayfa', icon: BarChart3, roles: ['admin', 'operator'] },
     { id: 'templates', label: 'Rapor Şablonları', icon: FileText, roles: ['admin', 'operator'] },
-    { id: 'archive-tags', label: 'Arşivlenecek Etiketler', icon: Archive, roles: ['admin', 'operator'] },
+    { id: 'archive-tags', label: 'Tag Arşivi', icon: Archive, roles: ['admin', 'operator'] },
     { id: 'operationclaims', label: 'Yetkiler', icon: Key, roles: ['admin'] },
     { id: 'useroperationclaims', label: 'Kullanıcı Yetkileri', icon: UserCog, roles: ['admin'] },
     { id: 'users', label: 'Kullanıcı Yönetimi', icon: Users, roles: ['admin'] },

--- a/src/components/Trend/TrendModal.tsx
+++ b/src/components/Trend/TrendModal.tsx
@@ -4,6 +4,7 @@ import {
   trendService,
   TrendPoint,
 } from '../../services';
+import { formatInterval } from '../../constants/intervalOptions';
 
 interface TrendModalProps {
   tag: ArchiveTagDto;
@@ -85,7 +86,7 @@ export const TrendModal: React.FC<TrendModalProps> = ({ tag, onClose }) => {
         <div className="grid grid-cols-2 gap-4 text-sm mb-4">
             <div><span className="font-medium">Node Id:</span> {tag.tagNodeId}</div>
             <div><span className="font-medium">Açıklama:</span> {tag.description ?? '-'}</div>
-            <div><span className="font-medium">Çekim Aralığı:</span> {tag.type}</div>
+            <div><span className="font-medium">Çekim Aralığı:</span> {formatInterval(tag.type)}</div>
             <div><span className="font-medium">Durum:</span> {tag.isActive ? 'Aktif' : 'Pasif'}</div>
           </div>
 

--- a/src/constants/intervalOptions.ts
+++ b/src/constants/intervalOptions.ts
@@ -1,0 +1,17 @@
+export const intervalOptions = [
+  { value: 1, label: '1sn' },
+  { value: 5, label: '5sn' },
+  { value: 10, label: '10sn' },
+  { value: 20, label: '20sn' },
+  { value: 30, label: '30sn' },
+  { value: 60, label: '1dk' },
+  { value: 300, label: '5dk' },
+  { value: 600, label: '10dk' },
+  { value: 3600, label: '1saat' },
+  { value: 86400, label: '1gün' },
+];
+
+export const formatInterval = (value: number) => {
+  const option = intervalOptions.find((o) => o.value === value);
+  return option ? option.label : String(value);
+};


### PR DESCRIPTION
## Summary
- Rename sidebar entry to "Tag Arşivi"
- Replace manual capture interval input with dropdown presets
- Display capture interval labels consistently across components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac25b065e88324ac16ac9710d9469f