### PR TITLE
Restrict editing of shared report templates

### DIFF
--- a/src/components/Templates/TemplateEditForm.tsx
+++ b/src/components/Templates/TemplateEditForm.tsx
@@ -14,12 +14,18 @@ export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSucces
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [showToast, setShowToast] = useState(false);
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
 
   useEffect(() => {
     const currentUser = authStore.getCurrentUser();
     if (!currentUser) return;
     templateService.getById(id, currentUser.id).then((res) => {
-      setName(res.name);
+      if (res.createdByUserId !== currentUser.id) {
+        setHasPermission(false);
+      } else {
+        setName(res.name);
+        setHasPermission(true);
+      }
     });
   }, [id]);
 
@@ -39,6 +45,26 @@ export const TemplateEditForm: React.FC<TemplateEditFormProps> = ({ id, onSucces
       setIsLoading(false);
     }
   };
+
+  if (hasPermission === false) {
+    return (
+      <div className="space-y-6 px-2">
+        <h1 className="text-2xl font-semibold text-gray-900">Şablonu Düzenle</h1>
+        <p className="text-sm text-red-600">Bu şablonu düzenleme yetkiniz yok.</p>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300 transition-colors"
+        >
+          Geri Dön
+        </button>
+      </div>
+    );
+  }
+
+  if (hasPermission === null) {
+    return null;
+  }
 
   return (
     <div className="space-y-6 px-2">

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -19,6 +19,7 @@ export const TemplateList: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
+  const currentUser = authStore.getCurrentUser();
 
   const loadData = () => {
     const currentUser = authStore.getCurrentUser();
@@ -65,6 +66,8 @@ export const TemplateList: React.FC = () => {
   };
 
   const handleDelete = (id: number) => {
+    const template = templates.find((t) => t.id === id);
+    if (template && template.createdByUserId !== currentUser?.id) return;
     setDeleteId(id);
   };
 
@@ -76,6 +79,8 @@ export const TemplateList: React.FC = () => {
   };
 
   const handleEdit = (id: number) => {
+    const template = templates.find((t) => t.id === id);
+    if (template && template.createdByUserId !== currentUser?.id) return;
     window.history.pushState({}, '', `/Templates/Edit/${id}`);
     window.dispatchEvent(new PopStateEvent('popstate'));
   };
@@ -148,20 +153,22 @@ export const TemplateList: React.FC = () => {
                 <h3 className="text-lg font-semibold text-gray-900">{template.name}</h3>
                 {/* description not provided by API */}
               </div>
-              <div className="flex items-center space-x-2">
-                <button
-                  onClick={() => handleEdit(template.id)}
-                  className="p-2 rounded-md text-gray-600 hover:bg-gray-50"
-                >
-                  <Edit2 className="h-4 w-4" />
-                </button>
-                <button
-                  onClick={() => handleDelete(template.id)}
-                  className="p-2 rounded-md text-red-600 hover:bg-red-50"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
+              {template.createdByUserId === currentUser?.id && (
+                <div className="flex items-center space-x-2">
+                  <button
+                    onClick={() => handleEdit(template.id)}
+                    className="p-2 rounded-md text-gray-600 hover:bg-gray-50"
+                  >
+                    <Edit2 className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(template.id)}
+                    className="p-2 rounded-md text-red-600 hover:bg-red-50"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              )}
             </div>
 
             <div className="space-y-2 text-sm">


### PR DESCRIPTION
## Summary
- Prevent editing/deleting report templates not created by current user
- Block unauthorized access to template edit form with clear message

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac4005250883249d4d14df9bd6007f