### PR TITLE
Add template sharing tabs and role labels

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -11,6 +11,19 @@ interface HeaderProps {
 export const Header: React.FC<HeaderProps> = ({ onLogout, onOpenUserSettings }) => {
   const currentUser = authStore.getCurrentUser();
 
+  const getRoleText = (role?: string) => {
+    switch (role) {
+      case 'admin':
+        return 'Yönetici';
+      case 'operator':
+        return 'Operatör';
+      case 'pending':
+        return 'Onay Bekliyor';
+      default:
+        return '';
+    }
+  };
+
   return (
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="px-4 sm:px-6 lg:px-8">
@@ -36,7 +49,7 @@ export const Header: React.FC<HeaderProps> = ({ onLogout, onOpenUserSettings }) 
               <User className="h-5 w-5 text-gray-400" />
               <div className="text-sm text-left">
                 <div className="font-medium text-gray-900">{currentUser?.username}</div>
-                <div className="text-gray-500 capitalize">{currentUser?.role}</div>
+                <div className="text-gray-500">{getRoleText(currentUser?.role)}</div>
               </div>
             </button>
             <button

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -21,6 +21,7 @@ export const TemplateList: React.FC = () => {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const currentUser = authStore.getCurrentUser();
+  const [activeTab, setActiveTab] = useState<'my' | 'shared'>('my');
 
   const loadData = () => {
     const currentUser = authStore.getCurrentUser();
@@ -81,9 +82,15 @@ export const TemplateList: React.FC = () => {
     loadData();
   }, []);
 
-  const filteredTemplates = templates.filter((template) =>
-    template.name.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const filteredTemplates = templates.filter((template) => {
+    const matchesSearch = template.name
+      .toLowerCase()
+      .includes(searchTerm.toLowerCase());
+    if (activeTab === 'my') {
+      return matchesSearch && template.createdByUserId === currentUser?.id;
+    }
+    return matchesSearch && template.createdByUserId !== currentUser?.id;
+  });
 
   const handleRefresh = () => {
     loadData();
@@ -151,6 +158,29 @@ export const TemplateList: React.FC = () => {
             <span>Yeni Şablon</span>
           </button>
         </div>
+      </div>
+
+      <div className="flex space-x-4 border-b pb-2">
+        <button
+          onClick={() => setActiveTab('my')}
+          className={`${
+            activeTab === 'my'
+              ? 'border-b-2 border-blue-600 text-blue-600'
+              : 'text-gray-500'
+          } pb-1`}
+        >
+          Şablonlarım
+        </button>
+        <button
+          onClick={() => setActiveTab('shared')}
+          className={`${
+            activeTab === 'shared'
+              ? 'border-b-2 border-blue-600 text-blue-600'
+              : 'text-gray-500'
+          } pb-1`}
+        >
+          Paylaşılanlar
+        </button>
       </div>
 
       {/* Search */}


### PR DESCRIPTION
## Summary
- show friendly role names in header
- separate personal and shared templates via tabs

## Testing
- `npm run lint`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b1892f0ed08325abc0c52690844c52