### PR TITLE
Group user and permission menus into a single hub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,16 +6,14 @@ import { Sidebar } from './components/Layout/Sidebar';
 import { Dashboard } from './components/Dashboard/Dashboard';
 import { TemplateList } from './components/Templates/TemplateList';
 import { TemplateEditForm } from './components/Templates/TemplateEditForm';
-import { SimpleUserList } from './components/Users/SimpleUserList';
 import { UserEditForm } from './components/Users/UserEditForm';
 import { LogList } from './components/Logs/LogList';
 import { Settings } from './components/Settings/Settings';
 import { TemplateTagManager } from './components/Templates/TemplateTagManager';
 import { TemplateShareManager } from './components/Templates/TemplateShareManager';
-import { OperationClaimList } from './components/OperationClaims/OperationClaimList';
-import { UserOperationClaimList } from './components/UserOperationClaims/UserOperationClaimList';
 import { UserSettings } from './components/Users/UserSettings';
 import { ArchiveTagList } from './components/ArchiveTags/ArchiveTagList';
+import { UserManagementHub } from './components/UserManagement/UserManagementHub';
 import { authStore } from './store/authStore';
 
 function App() {
@@ -51,12 +49,8 @@ function App() {
         return <TemplateList />;
       case 'archive-tags':
         return <ArchiveTagList />;
-      case 'operationclaims':
-        return <OperationClaimList />;
-      case 'useroperationclaims':
-        return <UserOperationClaimList />;
-      case 'users':
-        return <SimpleUserList />;
+      case 'user-management':
+        return <UserManagementHub />;
       case 'logs':
         return <LogList />;
       case 'settings':
@@ -98,7 +92,7 @@ function App() {
       <div className="h-screen overflow-hidden bg-gray-50">
         <Header onLogout={handleLogout} onOpenUserSettings={() => setActiveTab('user-settings')} />
         <div className="flex">
-          <Sidebar activeTab="users" onTabChange={(tab) => { setActiveTab(tab); navigate('/'); }} />
+          <Sidebar activeTab="user-management" onTabChange={(tab) => { setActiveTab(tab); navigate('/'); }} />
           <main className="flex-1 p-4">
             <div className="mx-2 max-w-none">
               <UserEditForm id={id} onSuccess={() => navigate('/Users')} onCancel={() => navigate('/Users')} />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -5,8 +5,6 @@ import {
   Users,
   Settings,
   Shield,
-  Key,
-  UserCog,
   Archive
 } from 'lucide-react';
 import { authStore } from '../../store/authStore';
@@ -24,9 +22,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeTab, onTabChange }) => {
     { id: 'dashboard', label: 'Anasayfa', icon: BarChart3, roles: ['admin', 'operator'] },
     { id: 'templates', label: 'Rapor Şablonları', icon: FileText, roles: ['admin', 'operator'] },
     { id: 'archive-tags', label: 'Tag Arşivi', icon: Archive, roles: ['admin', 'operator'] },
-    { id: 'operationclaims', label: 'Yetkiler', icon: Key, roles: ['admin'] },
-    { id: 'useroperationclaims', label: 'Kullanıcı Yetkileri', icon: UserCog, roles: ['admin'] },
-    { id: 'users', label: 'Kullanıcı Yönetimi', icon: Users, roles: ['admin'] },
+    { id: 'user-management', label: 'Kullanıcı Yönetimi', icon: Users, roles: ['admin'] },
     { id: 'logs', label: 'Sistem Logları', icon: Shield, roles: ['admin'] },
     { id: 'settings', label: 'Ayarlar', icon: Settings, roles: ['admin'] }
   ];

--- a/src/components/UserManagement/UserManagementHub.tsx
+++ b/src/components/UserManagement/UserManagementHub.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { OperationClaimList } from '../OperationClaims/OperationClaimList';
+import { UserOperationClaimList } from '../UserOperationClaims/UserOperationClaimList';
+import { SimpleUserList } from '../Users/SimpleUserList';
+
+type Section = 'operationclaims' | 'useroperationclaims' | 'users';
+
+const SECTIONS: { id: Section; label: string }[] = [
+  { id: 'operationclaims', label: 'Yetkiler' },
+  { id: 'useroperationclaims', label: 'Kullanıcı Yetkileri' },
+  { id: 'users', label: 'Kullanıcı Yönetimi' }
+];
+
+export const UserManagementHub: React.FC = () => {
+  const [activeSection, setActiveSection] = useState<Section>(SECTIONS[0].id);
+
+  const renderSection = () => {
+    switch (activeSection) {
+      case 'operationclaims':
+        return <OperationClaimList />;
+      case 'useroperationclaims':
+        return <UserOperationClaimList />;
+      case 'users':
+      default:
+        return <SimpleUserList />;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="px-2">
+        <nav
+          className="bg-white border border-gray-200 rounded-lg shadow-sm flex flex-wrap overflow-hidden"
+          role="tablist"
+          aria-label="Kullanıcı ve Yetki Yönetimi"
+        >
+          {SECTIONS.map((section) => (
+            <button
+              key={section.id}
+              type="button"
+              onClick={() => setActiveSection(section.id)}
+              role="tab"
+              aria-selected={activeSection === section.id}
+              className={`flex-1 min-w-[160px] px-4 py-3 text-sm font-medium transition-colors focus:outline-none border-r border-gray-200 last:border-r-0 ${
+                activeSection === section.id
+                  ? 'bg-blue-600 text-white shadow-inner'
+                  : 'text-gray-600 hover:bg-gray-100'
+              }`}
+            >
+              {section.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+      <div>{renderSection()}</div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- replace the separate Yetkiler, Kullanıcı Yetkileri, and Kullanıcı Yönetimi sidebar entries with a single consolidated menu item
- introduce a user management hub component that lets admins switch between permission and user lists from one screen
- update application routing so user edit flows highlight the new consolidated menu

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e0ddcebc8325ac4ea96a33cedfc1