### PR TITLE
Fix Turkish characters in JWT user names

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="tr">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -14,7 +14,7 @@ export const Dashboard: React.FC = () => {
       <div className="border-b mb-4">
         <nav className="flex space-x-4" aria-label="Tabs">
           <button className={tabClass('trend')} onClick={() => setTab('trend')}>
-            Trend
+            Trend Analizi
           </button>
           <button className={tabClass('system')} onClick={() => setTab('system')}>
             Sistem Bilgileri

--- a/src/components/Dashboard/SystemInfo.tsx
+++ b/src/components/Dashboard/SystemInfo.tsx
@@ -85,7 +85,7 @@ export const SystemInfo: React.FC = () => {
       ))}
 
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-gray-900">Anasayfa</h1>
+        <h1 className="text-2xl font-semibold text-gray-900">Sistem Bilgileri</h1>
         <div className="flex items-center space-x-2 text-sm text-gray-500">
           <ActivityIcon className="h-4 w-4" />
           <span>Son güncelleme: {new Date().toLocaleTimeString('tr-TR')}</span>
@@ -113,7 +113,7 @@ export const SystemInfo: React.FC = () => {
           color="blue"
         />
         <DashboardCard
-          title="Sistem Uptime"
+          title="Sistem Çalışma Süresi"
           value={stats.uptime}
           icon={TrendingUp}
           color="green"

--- a/src/components/Dashboard/SystemStatus.tsx
+++ b/src/components/Dashboard/SystemStatus.tsx
@@ -70,6 +70,20 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
     }
   };
 
+  const getStatusLabel = (status: string) => {
+    const normalized = normalizeStatus(status);
+    switch (normalized) {
+      case 'good':
+        return 'Sağlıklı';
+      case 'warning':
+        return 'Uyarı';
+      case 'bad':
+        return 'Kritik';
+      default:
+        return status;
+    }
+  };
+
   const formatValue = (metric: SystemMetric) => {
     if (metric.value === 1) {
       return 'Bağlı';
@@ -102,8 +116,8 @@ export const SystemStatus: React.FC<SystemStatusProps> = ({ metrics }) => {
               </div>
               <div className="text-right">
                 <p className="font-semibold text-gray-900">{formatValue(metric)}</p>
-                <p className={`text-sm font-medium capitalize ${getStatusTextColor(metric.status)}`}>
-                  {metric.status}
+                <p className={`text-sm font-medium ${getStatusTextColor(metric.status)}`}>
+                  {getStatusLabel(metric.status)}
                 </p>
               </div>
             </div>

--- a/src/components/Logs/LogList.tsx
+++ b/src/components/Logs/LogList.tsx
@@ -9,6 +9,19 @@ export const LogList: React.FC = () => {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [level, setLevel] = useState('');
 
+  const logLevelLabels: Record<LogLevel, string> = {
+    [LogLevel.Trace]: 'İzleme',
+    [LogLevel.Debug]: 'Hata Ayıklama',
+    [LogLevel.Info]: 'Bilgi',
+    [LogLevel.Warn]: 'Uyarı',
+    [LogLevel.Error]: 'Hata',
+    [LogLevel.Fatal]: 'Kritik Hata',
+  };
+
+  const logLevelOptions = Object.values(LogLevel).filter(
+    (value): value is LogLevel => typeof value === 'number'
+  );
+
   useEffect(() => {
     logService
       .list({ index: 0, size: 50 })
@@ -16,9 +29,8 @@ export const LogList: React.FC = () => {
       .catch(() => setLogs([]));
   }, []);
 
-  const levelToString = (level: LogLevel) => LogLevel[level];
-
-  const logLevels = Object.keys(LogLevel).filter((v) => isNaN(Number(v)));
+  const levelToString = (value: LogLevel) =>
+    logLevelLabels[value] ?? LogLevel[value];
 
   const filteredLogs = logs.filter((log) => {
     const date = new Date(log.createdAt);
@@ -65,9 +77,9 @@ export const LogList: React.FC = () => {
             className="border border-gray-300 rounded-md p-1"
           >
             <option value="">Tümü</option>
-            {logLevels.map((l) => (
-              <option key={l} value={LogLevel[l as keyof typeof LogLevel]}>
-                {l}
+            {logLevelOptions.map((logLevelValue) => (
+              <option key={logLevelValue} value={logLevelValue}>
+                {levelToString(logLevelValue)}
               </option>
             ))}
           </select>
@@ -107,7 +119,7 @@ export const LogList: React.FC = () => {
                     {log.message}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {new Date(log.createdAt).toLocaleString()}
+                    {new Date(log.createdAt).toLocaleString('tr-TR')}
                   </td>
                 </tr>
               ))}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -62,7 +62,7 @@ export const Settings: React.FC = () => {
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
-                OPC Server URL
+                OPC Sunucusu URL'si
               </label>
               <input
                 type="text"
@@ -173,10 +173,10 @@ export const Settings: React.FC = () => {
                 onChange={(e) => setSettings({...settings, logLevel: Number(e.target.value)})}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value={0}>Error</option>
-                <option value={1}>Warning</option>
-                <option value={2}>Info</option>
-                <option value={3}>Debug</option>
+                <option value={0}>Hata</option>
+                <option value={1}>Uyarı</option>
+                <option value={2}>Bilgi</option>
+                <option value={3}>Hata Ayıklama</option>
               </select>
             </div>
           </div>

--- a/src/components/Templates/TemplateList.tsx
+++ b/src/components/Templates/TemplateList.tsx
@@ -258,7 +258,7 @@ export const TemplateList: React.FC = () => {
                 </div>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-gray-600">Taglar:</span>
+                <span className="text-gray-600">Etiketler:</span>
                 <button
                   onClick={() => handleManageTags(template.id)}
                   className="px-2 py-1 text-sm bg-gray-200 rounded-md hover:bg-gray-300"

--- a/src/components/Templates/TemplateTagManager.tsx
+++ b/src/components/Templates/TemplateTagManager.tsx
@@ -109,7 +109,7 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
     <div className="space-y-6 px-2">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-gray-900">
-          Taglar - {templateName}
+          Etiketler - {templateName}
         </h1>
         <button
           onClick={onBack}
@@ -151,7 +151,7 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
                       Etiket Adı
                     </th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Node ID
+                      Düğüm Kimliği
                     </th>
                   </tr>
                 </thead>

--- a/src/components/Trend/TrendDashboard.tsx
+++ b/src/components/Trend/TrendDashboard.tsx
@@ -281,7 +281,7 @@ export const TrendDashboard: React.FC = () => {
               onClick={handleExport}
               className="ml-auto bg-green-600 text-white px-2 py-1 rounded"
             >
-              PDF
+              PDF Olarak Kaydet
             </button>
           </div>
 
@@ -361,10 +361,10 @@ export const TrendDashboard: React.FC = () => {
           </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-              <DashboardCard title="Max" value={max} icon={TrendingUp} color="blue" />
-              <DashboardCard title="Min" value={min} icon={TrendingDown} color="green" />
+              <DashboardCard title="Maksimum" value={max} icon={TrendingUp} color="blue" />
+              <DashboardCard title="Minimum" value={min} icon={TrendingDown} color="green" />
               <DashboardCard title="Ortalama" value={avg.toFixed(2)} icon={Activity} color="yellow" />
-              <DashboardCard title="Toplam" value={activePoints.length} icon={Hash} color="blue" />
+              <DashboardCard title="Örnek Sayısı" value={activePoints.length} icon={Hash} color="blue" />
             </div>
         </div>
       ) : (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
+document.documentElement.setAttribute('lang', 'tr');
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -5,7 +5,14 @@ function parseJwt(token: string): Record<string, unknown> | null {
   try {
     const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
     const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
-    const json = atob(padded);
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const json =
+      typeof TextDecoder !== 'undefined'
+        ? new TextDecoder('utf-8').decode(bytes)
+        : decodeURIComponent(
+            Array.from(bytes, (byte) => `%${byte.toString(16).padStart(2, '0')}`).join('')
+          );
     return JSON.parse(json);
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- decode JWT payloads with TextDecoder to preserve UTF-8 characters in user names
- add a safe fallback decoding path for environments without TextDecoder support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d62ac690388325a6954f8d752906eb