### PR TITLE
Use ReportTemplateArchiveTags service when assigning tags

### DIFF
--- a/src/components/Templates/TemplateCreateForm.tsx
+++ b/src/components/Templates/TemplateCreateForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   templateService,
   archiveTagService,
-  tagService,
+  reportTemplateArchiveTagService,
   ArchiveTagDto,
   userService,
   UserDto,
@@ -72,11 +72,9 @@ export const TemplateCreateForm: React.FC<TemplateCreateFormProps> = ({ onSucces
         sharedUserIds: Object.keys(shared),
       });
       for (const tag of Object.values(selected)) {
-        await tagService.create({
+        await reportTemplateArchiveTagService.create({
           reportTemplateId: template.id,
-          tagName: tag.tagName,
-          tagNodeId: tag.tagNodeId,
-          description: tag.description,
+          archiveTagId: tag.id,
         });
       }
       onSuccess();

--- a/src/components/Templates/TemplateTagManager.tsx
+++ b/src/components/Templates/TemplateTagManager.tsx
@@ -4,6 +4,7 @@ import {
   tagService,
   templateService,
   archiveTagService,
+  reportTemplateArchiveTagService,
   ReportTemplateTagDto,
   ArchiveTagDto,
   userService,
@@ -81,11 +82,9 @@ export const TemplateTagManager: React.FC<TemplateTagManagerProps> = ({
   const saveTags = async () => {
     for (const tag of Object.values(selected)) {
       if (!tags.some((t) => t.tagNodeId === tag.tagNodeId)) {
-        await tagService.create({
+        await reportTemplateArchiveTagService.create({
           reportTemplateId: templateId,
-          tagName: tag.tagName,
-          tagNodeId: tag.tagNodeId,
-          description: tag.description,
+          archiveTagId: tag.id,
         });
       }
     }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,3 +12,4 @@ export * from './systemSettingsService';
 export * from './logService';
 export * from './archiveTagService';
 export * from './trendService';
+export * from './reportTemplateArchiveTagService';

--- a/src/services/reportTemplateArchiveTagService.ts
+++ b/src/services/reportTemplateArchiveTagService.ts
@@ -1,0 +1,11 @@
+import { api } from './api';
+
+export interface ReportTemplateArchiveTagCreateDto {
+  reportTemplateId: number;
+  archiveTagId: number;
+}
+
+export const reportTemplateArchiveTagService = {
+  create: (data: ReportTemplateArchiveTagCreateDto) =>
+    api.post('/api/ReportTemplateArchiveTags', data),
+};


### PR DESCRIPTION
## Summary
- add a service wrapper for the ReportTemplateArchiveTags endpoint
- update template creation and tag management flows to persist selections through the new API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db90e8443c8325b8fc75d6a3ecb227